### PR TITLE
fix: close editor when level change and not allowed

### DIFF
--- a/app/client/lemverse.js
+++ b/app/client/lemverse.js
@@ -235,9 +235,6 @@ Template.lemverse.onCreated(function () {
     this.handleZonesSubscribe = this.subscribe('zones', levelId, () => zones.checkDistances());
 
     log(`Loading tiles for the level ${levelId || 'unknown'}…`);
-    if (!isEditionAllowed(Meteor.userId())) {
-      Session.set('editor', false);
-    }
     this.handleTilesSubscribe = this.subscribe('tiles', levelId, () => {
       this.handleObserveTiles = Tiles.find().observe({
         added(tile) {

--- a/app/client/lemverse.js
+++ b/app/client/lemverse.js
@@ -235,6 +235,9 @@ Template.lemverse.onCreated(function () {
     this.handleZonesSubscribe = this.subscribe('zones', levelId, () => zones.checkDistances());
 
     log(`Loading tiles for the level ${levelId || 'unknown'}…`);
+    if (!isEditionAllowed(Meteor.userId())) {
+      Session.set('editor', false);
+    }
     this.handleTilesSubscribe = this.subscribe('tiles', levelId, () => {
       this.handleObserveTiles = Tiles.find().observe({
         added(tile) {

--- a/app/client/scene-world.js
+++ b/app/client/scene-world.js
@@ -635,6 +635,9 @@ WorldScene = new Phaser.Class({
     this.update(0, 0);
 
     setTimeout(() => game.scene.keys.LoadingScene.hide(() => {
+      if (!isEditionAllowed(Meteor.userId())) {
+        Session.set('editor', false);
+      }
       this.input.keyboard.enabled = true;
       if (this.player) this.player.visible = true;
       this.scene.resume();


### PR DESCRIPTION
When changing level from editor allowed to not, editor interface stay and we cannot close it anymore.
This Pr will make it close automatically