### PR TITLE
fix: tileset guid start at 1 to allow auto increment

### DIFF
--- a/app/server/files.js
+++ b/app/server/files.js
@@ -31,7 +31,7 @@ const filesAfterUploadEditorTileset = (user, fileRef) => {
     // Create
     log('filesAfterUploadEditorTileset: create a new tileset', { userId: user._id, fileId: fileRef._id });
     const maxTileset = Tilesets.findOne({}, { sort: { gid: -1 }, limit: 1 });
-    let maxTilesetGid = 0;
+    let maxTilesetGid = 1;
     if (maxTileset?.gid) maxTilesetGid = maxTileset.gid + 10000;
 
     const newId = Tilesets.id();


### PR DESCRIPTION
Change first gid to 1 instead of 0.
to make the `if (maxTileset?.gid)` work for the next upload tile