### PR TITLE
fix: zone-toolbox editor

### DIFF
--- a/app/client/zones-toolbox.hbs.html
+++ b/app/client/zones-toolbox.hbs.html
@@ -1,8 +1,7 @@
 <template name="zonesToolboxProperties">
   <div class="modal zones-toolbox-properties">
     <div>
-      {{#if name}}{{name}}{{else}}{{_id}}{{/if}}
-      <br><br>
+      <h3>{{#if name}}{{name}}{{else}}{{_id}}{{/if}}</h3>
       <textarea>{{properties}}</textarea>
     </div>
     <div>

--- a/app/client/zones-toolbox.scss
+++ b/app/client/zones-toolbox.scss
@@ -50,6 +50,8 @@
 
   >div {
     display: flex;
+    flex-direction: column;
+    height: 100%;
   }
 
   > :first-child {

--- a/app/client/zones-toolbox.scss
+++ b/app/client/zones-toolbox.scss
@@ -50,8 +50,6 @@
 
   >div {
     display: flex;
-    flex-direction: column;
-    height: 100%;
   }
 
   > :first-child {


### PR DESCRIPTION
Make popup keep working with long zone name
<img width="438" alt="Screenshot 2021-09-17 at 12 42 47" src="https://user-images.githubusercontent.com/4084527/133762466-e917f336-f24b-4517-84de-88fdda27515a.png">
s
