### PR TITLE
feat: add colision in tileset-editor and refactor design

### DIFF
--- a/app/client/lemverse.scss
+++ b/app/client/lemverse.scss
@@ -282,7 +282,6 @@ button:focus {
   border-radius: 4px;
   margin: 5px 1px;
   padding: 0 4px;
-  cursor: pointer;
 
   &:hover {
     background-color: #E5E9F0;

--- a/app/client/tileset-toolbox.hbs.html
+++ b/app/client/tileset-toolbox.hbs.html
@@ -2,7 +2,7 @@
   <div style="display: inline-block; background-image: url('/api/files/{{tileset.fileId}}'); width: 16px; height: 16px; background-position: -{{tileToTilesetX}}px -{{tileToTilesetY}}px;"></div>
 </template>
 <template name="tileData">
-  <div class="tileData" style="{{#if hasCollision index}}border-color:#FF0000;{{/if}}">{{> tileImg}} {{tileLayer}}</div>
+  <div class="tileData" style="{{#if hasCollision tilesetId index}}border-color:#FF0000;{{/if}}">{{> tileImg}} {{tileLayer}}</div>
 </template>
 
 <template name="tilesetToolbox">

--- a/app/client/tileset-toolbox.hbs.html
+++ b/app/client/tileset-toolbox.hbs.html
@@ -1,8 +1,9 @@
 <template name="tileImg">
   <div style="display: inline-block; background-image: url('/api/files/{{tileset.fileId}}'); width: 16px; height: 16px; background-position: -{{tileToTilesetX}}px -{{tileToTilesetY}}px;"></div>
 </template>
+
 <template name="tileData">
-  <div class="tileData" style="{{#if hasCollision tilesetId index}}border-color:#FF0000;{{/if}}">{{> tileImg}} {{tileLayer}}</div>
+  <div class="tileData {{#if hasCollision tilesetId index}}has-collision{{/if}}">{{> tileImg}} {{tileLayer}}</div>
 </template>
 
 <template name="tilesetToolbox">
@@ -44,11 +45,11 @@
       <div class="tileset-toolbox-info">
         <div>Pointer x: {{worldToTileX (Session 'pointerX')}} y: {{worldToTileY (Session 'pointerY')}}
           {{#each pointerTile}}
-          {{> tileData}}
-        {{/each}}
+            {{> tileData}}
+          {{/each}}
         </div>
         {{#with Session 'selectedTiles'}}
-        Selected {{> tileData}}
+          Selected {{> tileData}}
         {{/with}}
       </div>
     </div>

--- a/app/client/tileset-toolbox.hbs.html
+++ b/app/client/tileset-toolbox.hbs.html
@@ -1,6 +1,9 @@
 <template name="tileImg">
   <div style="display: inline-block; background-image: url('/api/files/{{tileset.fileId}}'); width: 16px; height: 16px; background-position: -{{tileToTilesetX}}px -{{tileToTilesetY}}px;"></div>
 </template>
+<template name="tileData">
+  <div class="tileData" style="{{#if hasCollision index}}border-color:#FF0000;{{/if}}">{{> tileImg}} {{tileLayer}}</div>
+</template>
 
 <template name="tilesetToolbox">
   <div class="tileset-toolbox">
@@ -36,14 +39,17 @@
         <span class="button js-erase-8 {{#if eq selectedTilesIndex -9}}active{{/if}}">🧽8</span>
         <span class="button js-erase-all {{#if eq selectedTilesIndex -99}}active{{/if}}">🧽C</span>
       </div>
+    </div>
+    <div>
       <div class="tileset-toolbox-info">
-        {{#with Session 'selectedTiles'}}
-          Selected {{tileLayer}} {{> tileImg}}
-        {{/with}}
-        Pointer {{worldToTileX (Session 'pointerX')}}/{{worldToTileY (Session 'pointerY')}} ({{Session 'pointerX'}}/{{Session 'pointerY'}})
-        {{#each pointerTile}}
-          {{tileLayer}} {{> tileImg}}
+        <div>Pointer {{worldToTileX (Session 'pointerX')}}/{{worldToTileY (Session 'pointerY')}}
+          {{#each pointerTile}}
+          {{> tileData}}
         {{/each}}
+        </div>
+        {{#with Session 'selectedTiles'}}
+        Selected {{> tileData}}
+        {{/with}}
       </div>
     </div>
   </div>

--- a/app/client/tileset-toolbox.hbs.html
+++ b/app/client/tileset-toolbox.hbs.html
@@ -42,7 +42,7 @@
     </div>
     <div>
       <div class="tileset-toolbox-info">
-        <div>Pointer {{worldToTileX (Session 'pointerX')}}/{{worldToTileY (Session 'pointerY')}}
+        <div>Pointer
           {{#each pointerTile}}
           {{> tileData}}
         {{/each}}

--- a/app/client/tileset-toolbox.hbs.html
+++ b/app/client/tileset-toolbox.hbs.html
@@ -42,7 +42,7 @@
     </div>
     <div>
       <div class="tileset-toolbox-info">
-        <div>Pointer
+        <div>Pointer x: {{worldToTileX (Session 'pointerX')}} y: {{worldToTileY (Session 'pointerY')}}
           {{#each pointerTile}}
           {{> tileData}}
         {{/each}}

--- a/app/client/tileset-toolbox.js
+++ b/app/client/tileset-toolbox.js
@@ -85,6 +85,10 @@ Template.tilesetToolbox.onDestroyed(() => {
   unbindKeyboardShortcuts();
 });
 
+Template.tileData.helpers({
+  hasCollision(index) { return selectedTileset().collisionTileIndexes.includes(index); },
+});
+
 Template.tilesetToolbox.helpers({
   pointerTile() { return pointerToTile(); },
   user(userId) { return Meteor.users.findOne(userId); },

--- a/app/client/tileset-toolbox.js
+++ b/app/client/tileset-toolbox.js
@@ -86,7 +86,10 @@ Template.tilesetToolbox.onDestroyed(() => {
 });
 
 Template.tileData.helpers({
-  hasCollision(index) { return selectedTileset().collisionTileIndexes.includes(index); },
+  hasCollision(tilesetId, index) {
+    const tileset = Tilesets.findOne(tilesetId);
+    return tileset.collisionTileIndexes.includes(index); 
+  },
 });
 
 Template.tilesetToolbox.helpers({

--- a/app/client/tileset-toolbox.scss
+++ b/app/client/tileset-toolbox.scss
@@ -30,6 +30,16 @@
   .js-tilesets-select {
     width: 100%;
   }
+  
+  .tileData {
+    display: inline-block;
+    border: 1px solid #4C566A;
+    color: #4C566A;
+    background-color: white;
+    border-radius: 4px;
+    margin: 5px 1px;
+    padding: 4px;
+  }
 
   .tileset-toolbox-erase {
     height: 200px;

--- a/app/client/tileset-toolbox.scss
+++ b/app/client/tileset-toolbox.scss
@@ -30,7 +30,7 @@
   .js-tilesets-select {
     width: 100%;
   }
-  
+
   .tileData {
     display: inline-block;
     border: 1px solid #4C566A;
@@ -39,6 +39,10 @@
     border-radius: 4px;
     margin: 5px 1px;
     padding: 4px;
+
+    &.has-collision {
+      border-color: #FF0000;
+    }
   }
 
   .tileset-toolbox-erase {

--- a/app/client/tileset-toolbox.scss
+++ b/app/client/tileset-toolbox.scss
@@ -1,3 +1,5 @@
+@import "_variables";
+
 .tileset-toolbox {
   position: fixed;
   left: 0;
@@ -41,7 +43,10 @@
     padding: 4px;
 
     &.has-collision {
-      border-color: #FF0000;
+      border-color: rgba($lem-color-7, 0.5);
+      background-color: rgba($lem-color-7, 0.2);
+      color: $lem-color-7;
+      font-weight: bold;
     }
   }
 


### PR DESCRIPTION
This was reported by 4 users who didn't get info of tile.
As it was reported there : https://github.com/l3mpire/lemverse/issues/33
After few iteration i got this as starting point to refactor the design of selected and pointer design.
Now:
<img width="745" alt="Screenshot 2021-11-05 at 19 26 19" src="https://user-images.githubusercontent.com/4084527/140567606-df286112-7de4-483b-bd87-c754d7b522c2.png">

Before:
<img width="724" alt="Screenshot 2021-11-05 at 19 20 45" src="https://user-images.githubusercontent.com/4084527/140566837-58b4c8ff-889b-4213-a7d4-d97be3fe620d.png">

The red border represent the colision information
Pointer and selection have move to new column
Tile design fit to tile eraser design
Removed pixel position
Change tile postion format from `(14/7)` to `x: 14 y: 7`