### PR TITLE
Make the README's Table of contents functional on GitHub :)

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,11 +12,11 @@
 </div>
 
 # Table of contents
-- [What is `lemverse`?](#what-is--lemverse--)
-- [What can I do in lemverse?](#what-can-i-do-in-lemverse-)
-- [Getting started!](#getting-started-)
-- [Deploy in production!](#deploy-in-production-)
-- [Useful commands/tricks](#useful-commands-tricks)
+- [What is `lemverse`?](#what-is-lemverse)
+- [What can I do in lemverse?](#what-can-i-do-in-lemverse)
+- [Getting started!](#getting-started)
+- [Deploy in production!](#deploy-in-production)
+- [Useful commands/tricks](#useful-commandstricks)
 - [Assets](#assets)
 - [License](#license)
 - [Credits](#credits)


### PR DESCRIPTION
Hey there!

I don't know why the table of contents is the way it is, but removing some dashes is necessary to make it work on GitHub.