### PR TITLE
Improve world zoom

### DIFF
--- a/README.md
+++ b/README.md
@@ -349,7 +349,13 @@ Please note, that as stated in section `Deploy in production`, there is an addit
 
     "defaultReaction": "❤️",
 
-    "zoom": 1,
+    "zoom": {
+      "default": 1, // Default zoom level
+      "min": 0.6, // Minimum zoom level
+      "max": 1.6, // Maximum zoom level
+      "factor": 0.001, // Zoom factor (increase to zoom faster, decrease to zoom slower)
+      "maxDelta": 100 // Maximum zooming delta
+    },
 
     "peer": {
       // Settings about webrtc connection

--- a/app/_settings.json
+++ b/app/_settings.json
@@ -14,7 +14,13 @@
 
     "defaultReaction": "❤️",
 
-    "zoom": 1,
+    "zoom": {
+      "default": 1,
+      "min": 0.6,
+      "max": 1.6,
+      "factor": 0.001,
+      "maxDelta": 100
+    },
 
     "peer": {
       "answerMaxAttempt": 5,

--- a/app/settings-dev.json
+++ b/app/settings-dev.json
@@ -14,7 +14,13 @@
 
     "defaultReaction": "❤️",
 
-    "zoom": 1,
+    "zoom": {
+      "default": 1,
+      "min": 0.6,
+      "max": 1.6,
+      "factor": 0.001,
+      "maxDelta": 100
+    },
 
     "peer": {
       "answerMaxAttempt": 5,

--- a/core/client/helpers.js
+++ b/core/client/helpers.js
@@ -86,6 +86,8 @@ updateViewport = (scene, mode) => {
   scene.viewportMode = mode;
 };
 
+clamp = (value, min, max) => Math.min(Math.max(value, min), max);
+
 formatURL = url => {
   let formattedURL;
   try {


### PR DESCRIPTION
- add configurable zoom settings
- set default zoom at start-up
- add linear zooming (zoom out become gradually slower)
- clamp zoom to world bounds (prevent zooming out when the map reach its full height or width)
- fix the zoom direction

A `maxDelta` parameter has been added, it allows to avoid savage zooming out in one shot
using mouse wheel.