### PR TITLE
Improve discussions analytics

### DIFF
--- a/core/server/analytics.js
+++ b/core/server/analytics.js
@@ -117,27 +117,67 @@ Meteor.methods({
 
     analytics.updateUser(editedUserId, traits);
   },
-  analyticsDiscussionAttend(traits) {
+  analyticsDiscussionStart(properties) {
     const { userId } = this;
     if (!userId) return;
 
-    check(traits, {
-      users_attending_count: Number,
+    check(properties, {
+      peerUserId: String,
     });
 
     const user = Meteor.user();
-    analytics.track(userId, '💬 Discussion Attend', { level_id: user.profile.levelId });
+    analytics.track(userId, '💬 ✅ Discussion Start', {
+      level_id: user.profile.levelId,
+      peer_user_id: properties.peerUserId,
+    });
   },
-  analyticsDiscussionEnd(traits) {
+  analyticsDiscussionJoin(properties) {
     const { userId } = this;
     if (!userId) return;
 
-    check(traits, {
-      duration: Number,
+    check(properties, {
+      peerUserId: String,
     });
 
     const user = Meteor.user();
-    analytics.track(userId, '💬 Discussion End', { level_id: user.profile.levelId, duration: traits.duration });
+    analytics.track(userId, '💬 ➡️ Discussion Join', {
+      level_id: user.profile.levelId,
+      peer_user_id: properties.peerUserId,
+    });
+  },
+  analyticsDiscussionEnd(properties) {
+    const { userId } = this;
+    if (!userId) return;
+
+    check(properties, {
+      totalDuration: Number,
+      duration: Number,
+      peerUserId: String,
+    });
+
+    const user = Meteor.user();
+    analytics.track(userId, '💬 🛑 Discussion End', {
+      level_id: user.profile.levelId,
+      duration: properties.duration,
+      total_duration: properties.totalDuration,
+      peer_user_id: properties.peerUserId,
+    });
+  },
+  analyticsDiscussionLeft(properties) {
+    const { userId } = this;
+    if (!userId) return;
+
+    check(properties, {
+      duration: Number,
+      peerUserId: String,
+    });
+
+    const user = Meteor.user();
+    analytics.track(userId, '💬 ⬅️ Discussion Left', {
+      level_id: user.profile.levelId,
+      duration: properties.duration,
+      peer_user_id: properties.peerUserId,
+    });
   },
   analyticsConferenceAttend(traits) {
     const { userId } = this;


### PR DESCRIPTION
Four events are used during discussions:

DiscussionStart : when a user has a discussion started
 - level_id : The level id
 - peer_user_id : The user id of the remote user

DiscussionJoin : when a user has already a discussion started and another is joining
 - level_id : The level id
 - peer_user_id : The user id of the joining user

DiscussionLeft : when a user has someone leaving its discussion but is not the last one
 - level_id : The level id
 - peer_user_id : The user id of the leaving user
 - duration : The duration of the call with the leaving user

DiscussionEnd : when a user has a discussion finished
 - level_id : The level id
 - peer_user_id : The user id of the last user
 - duration : The duration of the call with the last user
 - total_duration : The total duration of the current discussion (should be equal to duration for a 1:1 call)