### PR TITLE
Improve discussions analytics

### DIFF
--- a/core/server/analytics.js
+++ b/core/server/analytics.js
@@ -122,22 +122,34 @@ Meteor.methods({
     if (!userId) return;
 
     check(traits, {
-      users_attending_count: Number,
+      peerUserId: String,
+      usersAttendingCount: Number,
     });
 
     const user = Meteor.user();
-    analytics.track(userId, '💬 Discussion Attend', { level_id: user.profile.levelId });
+    analytics.track(userId, '💬 Discussion Attend', {
+      level_id: user.profile.levelId,
+      peer_user_id: traits.peerUserId,
+      users_attending_count: traits.usersAttendingCount,
+    });
   },
   analyticsDiscussionEnd(traits) {
     const { userId } = this;
     if (!userId) return;
 
     check(traits, {
+      usersAttendingCount: Number,
       duration: Number,
+      peerUserId: String,
     });
 
     const user = Meteor.user();
-    analytics.track(userId, '💬 Discussion End', { level_id: user.profile.levelId, duration: traits.duration });
+    analytics.track(userId, '💬 Discussion End', {
+      level_id: user.profile.levelId,
+      duration: traits.duration,
+      users_attending_count: traits.usersAttendingCount,
+      peer_user_id: traits.peerUserId,
+    });
   },
   analyticsConferenceAttend(traits) {
     const { userId } = this;


### PR DESCRIPTION
`DiscussionAttend` and `DiscussionEnd` events are now thrown also when a user joins or leaves an existing discussion.

`users_attending_count`: This property allows to know how many users were in the discussions before the join/left and thus allows to filter new discussions/discussions ending if needed.

`peer_user_id:` The user id of the user joining/leaving the discussion.

The choice of throwing the same events with a `users_attending_count` rather than new events (e.g. `DiscussionJoin`, `DiscussionLeft`) is because it is easier in most analytics tools to filter on properties rather than aggregating events.