### PR TITLE
Improve log-in analytics

### DIFF
--- a/core/server/accounts.js
+++ b/core/server/accounts.js
@@ -35,7 +35,7 @@ Accounts.onLogin(param => {
     generateRandomCharacterSkin(user._id, Meteor.settings.defaultLevelId);
   }
 
-  if (param.type !== 'resume') analytics.track(user._id, '👋 Sign In');
+  analytics.track(user._id, '👋 Sign In', { type: param.type });
 });
 
 Accounts.validateLoginAttempt(param => {


### PR DESCRIPTION
Rename `Sign In` event to `Log In` and throws it even when the user resume log-in.

The property `type` (`password` or `resume`) allows to track both types of log-in.