### PR TITLE
Add possibility to override jitsi meet config options

### DIFF
--- a/app/_settings.json
+++ b/app/_settings.json
@@ -32,7 +32,8 @@
 
     "meet": {
       "serverURL": "meet.jit.si",
-      "roomDefaultName": "lemverse-test"
+      "roomDefaultName": "lemverse-test",
+      "configOverwrite": {}
     },
 
     "character": {

--- a/app/settings-dev.json
+++ b/app/settings-dev.json
@@ -32,7 +32,8 @@
 
     "meet": {
       "serverURL": "meet.jit.si",
-      "roomDefaultName": "lemverse-test"
+      "roomDefaultName": "lemverse-test",
+      "configOverwrite": {}
     },
 
     "character": {

--- a/core/modules/meet/client/meet.js
+++ b/core/modules/meet/client/meet.js
@@ -98,6 +98,7 @@ meetHighLevel = {
 
     const user = Meteor.user();
     const currentZone = zoneManager.currentZone();
+    const configOverwrite = Meteor.settings.public.meet.configOverwrite || {};
 
     const options = {
       width: '100%',
@@ -111,6 +112,7 @@ meetHighLevel = {
         startWithAudioMuted: !currentZone.unmute,
         startWithVideoMuted: !currentZone.unhide,
         disableTileView: !currentZone.unhide,
+        ...configOverwrite,
       },
       roomName: config.roomName,
       jwt: config.token,


### PR DESCRIPTION
Actually we can't override Jitsi meet options as we can found them here : https://github.com/jitsi/jitsi-meet/blob/master/config.js

I've added a simple solution to override it dynamically.