### PR TITLE
Add passwordless login

### DIFF
--- a/README.md
+++ b/README.md
@@ -387,6 +387,8 @@ Please note, that as stated in section `Deploy in production`, there is an addit
       "contactURL": ""
     },
 
+    "passwordless": false, // Activate to use magic link emails instead of password for log-in
+
     "assets": {
       // Assets configuration
       "character": {

--- a/app/.meteor/packages
+++ b/app/.meteor/packages
@@ -48,3 +48,4 @@ accounts-twitter@1.5.0
 accounts-github@1.5.0
 accounts-google@1.4.0
 accounts-facebook@1.3.3
+accounts-passwordless@2.1.3

--- a/app/.meteor/versions
+++ b/app/.meteor/versions
@@ -5,6 +5,7 @@ accounts-google@1.4.0
 accounts-guest@0.0.1
 accounts-oauth@1.4.1
 accounts-password@2.3.1
+accounts-passwordless@2.1.3
 accounts-twitter@1.5.0
 accounts-ui@1.4.2
 accounts-ui-unstyled@1.7.0

--- a/app/_settings.json
+++ b/app/_settings.json
@@ -136,6 +136,8 @@
       "contactURL": ""
     },
 
+    "passwordless": false,
+
     "skins": {
       "guest": {},
       "default": {}

--- a/app/settings-dev.json
+++ b/app/settings-dev.json
@@ -49,6 +49,8 @@
       "contactURL": ""
     },
 
+    "passwordless": false,
+
     "assets": {
       "character": {
         "frameWidth": 16,

--- a/core/client/passwordless.js
+++ b/core/client/passwordless.js
@@ -1,0 +1,31 @@
+const checkToken = ({ selector, token }) => {
+  if (!token) {
+    return;
+  }
+  Meteor.passwordlessLoginWithToken(selector, token, () => {
+    // Make it look clean by removing the authToken from the URL
+    if (window.history) {
+      const url = window.location.href.split('?')[0];
+      window.history.pushState(null, null, url);
+    }
+  });
+};
+
+/**
+ * Parse querystring for token argument, if found use it to auto-login
+ */
+Accounts.autoLoginWithToken = function () {
+  Meteor.startup(() => {
+    const params = new URL(window.location.href).searchParams;
+
+    if (params.get('loginToken')) {
+      checkToken({
+        selector: params.get('selector'),
+        token: params.get('loginToken'),
+      });
+    }
+  });
+};
+
+// Run check for login token on page load
+Meteor.startup(() => Accounts.autoLoginWithToken());

--- a/core/client/ui/_forms.scss
+++ b/core/client/ui/_forms.scss
@@ -105,4 +105,8 @@
     color: lighten($light-blue, 10%);
     cursor: pointer;
   }
+
+  &[disabled] {
+    pointer-events: none;
+  }
 }

--- a/core/client/ui/form-log-in.hbs.html
+++ b/core/client/ui/form-log-in.hbs.html
@@ -1,42 +1,62 @@
 <template name="formLogIn">
   <div class="form-account {{#unless visible}}visible{{/unless}}">
-    {{#if restrictedRegistration}}
-      <h1 class="title">Welcome to lemverse</h1>
-      <h2 class="title">Log to my account</h2>
-    {{else}}
-      <h1 class="title">Log to my account or create a new one</h1>
-    {{/if}}
-    <div class="step">
-      <form>
-        <div class="group-field">
-          <label for="email">Email Address:</label>
-          <input name="email" type="email" value="{{email}}" class="js-edit js-email" autofocus>
-        </div>
-        {{#if loginMode}}
-          <div class="group-field">
-            <label for="password">Password:</label>
-            <input name="password" type="password" value="{{password}}" class="js-edit js-password">
-          </div>
-          <button type="button" class="link js-password-lost" aria-label="recover my password">I lost my password</button>
-          <button type="submit" class="submit" aria-label="go to the next step">Log in</button>
-        {{else}}
-          <button type="submit" class="button submit" aria-label="send email to recover my password">Recover my password</button>
-        {{/if}}
-      </form>
-    </div>
+    {{#if emailSent}}
+      <div class="step">
+        <h1 class="title">Check your email 📥</h1>
+        <p class="title">We've sent your magic link to <b>{{email}}</b>.</p>
+        <p>Click on the link in your email to log-in.</p>
+      </div>
 
-    {{#if not restrictedRegistration}}
       <div class="bottom">
-        {{#if loginMode}}
-          <a href="?mode=create" class="link">Missing an account, join there!</a>
-        {{else}}
-          <button type="button" class="link js-cancel-login-mode" aria-label="cancel">Cancel</button>
-        {{/if}}
+        <form>
+          <button type="submit" class="link {{#unless canRetry}}disabled{{/unless}}" aria-label="re-send email" disabled={{canRetry}} >
+            Didn't receive the email? Click here {{#if counter }} in {{counter}} s {{/if}} to try again.
+          </button>
+        </form>
       </div>
-    {{else if (and restrictedRegistration contactURL)}}
-      <div class="bottom">
-        <p><a href="{{contactURL}}" target="_blank" rel="noopener">Contact us</a> to create your own customized virtual office on lemverse</p>
+    {{else}}
+      {{#if restrictedRegistration}}
+        <h1 class="title">Welcome to lemverse</h1>
+        <h2 class="title">Log to my account</h2>
+      {{else}}
+        <h1 class="title">Log to my account or create a new one</h1>
+      {{/if}}
+      <div class="step">
+        <form>
+          <div class="group-field">
+            <label for="email">Email Address:</label>
+            <input name="email" type="email" value="{{email}}" class="js-edit js-email" autofocus>
+          </div>
+          {{#if loginMode}}
+            {{#if passwordless}}
+              <button type="submit" class="button submit" aria-label="send magic link email">Send</button>
+            {{else}}
+              <div class="group-field">
+                <label for="password">Password:</label>
+                <input name="password" type="password" value="{{password}}" class="js-edit js-password">
+              </div>
+              <button type="button" class="link js-password-lost" aria-label="recover my password">I lost my password</button>
+              <button type="submit" class="submit" aria-label="go to the next step">Log in</button>
+            {{/if}}
+          {{else}}
+            <button type="submit" class="button submit" aria-label="send email to recover my password">Recover my password</button>
+          {{/if}}
+        </form>
       </div>
+
+      {{#if not restrictedRegistration}}
+        <div class="bottom">
+          {{#if loginMode}}
+            <a href="?mode=create" class="link">Missing an account, join there!</a>
+          {{else}}
+            <button type="button" class="link js-cancel-login-mode" aria-label="cancel">Cancel</button>
+          {{/if}}
+        </div>
+      {{else if (and restrictedRegistration contactURL)}}
+        <div class="bottom">
+          <p><a href="{{contactURL}}" target="_blank" rel="noopener">Contact us</a> to create your own customized virtual office on lemverse</p>
+        </div>
+      {{/if}}
     {{/if}}
   </div>
 </template>

--- a/core/client/ui/form-sign-in.js
+++ b/core/client/ui/form-sign-in.js
@@ -17,6 +17,24 @@ const checkPassword = value => {
   return true;
 };
 
+const nextStep = template => {
+  const step = template.step.get();
+  if (Meteor.settings.public.passwordless && step === 2) {
+    template.step.set(4);
+  } else {
+    template.step.set(step + 1);
+  }
+};
+
+const previousStep = template => {
+  const step = template.step.get();
+  if (Meteor.settings.public.passwordless && step === 4) {
+    template.step.set(2);
+  } else {
+    template.step.set(step - 1);
+  }
+};
+
 const onSubmit = template => {
   const step = template.step.get();
 
@@ -28,7 +46,7 @@ const onSubmit = template => {
   if (checkedResult !== true) { lp.notif.error(checkedResult); return; }
 
   if (step < 4) {
-    template.step.set(step + 1);
+    nextStep(template);
 
     // auto-focus first input on each step
     Tracker.afterFlush(() => document.querySelector('.form-account form input')?.focus());
@@ -50,13 +68,13 @@ const onSubmit = template => {
 Template.formSignIn.onCreated(function () {
   this.step = new ReactiveVar(1);
   this.email = undefined;
-  this.password = undefined;
+  this.password = Meteor.settings.public.passwordless ? '' : undefined;
   this.nickname = undefined;
 });
 
 Template.formSignIn.events({
   'click .js-next-step'() { onSubmit(Template.instance()); },
-  'click .js-previous-step'() { Template.instance().step.set(Template.instance().step.get() - 1); },
+  'click .js-previous-step'() { previousStep(Template.instance()); },
   'keyup .js-email'(event, templateInstance) { templateInstance.email = event.target.value; },
   'keyup .js-password'(event, templateInstance) { templateInstance.password = event.target.value; },
   'keyup .js-nickname'(event, templateInstance) { templateInstance.nickname = event.target.value; },

--- a/core/server/email-templates.js
+++ b/core/server/email-templates.js
@@ -1,0 +1,15 @@
+const encodeSelector = url => url.replace(/(selector=)(.*)/, (_, p1, p2) => p1 + encodeURIComponent(p2));
+
+Accounts.emailTemplates.sendLoginToken = {
+  subject: () => `Your login magic link for ${Accounts.emailTemplates.siteName}`,
+  text: (user, url) => `Hello! 👋
+Click the following link to be automatically logged in:
+${encodeSelector(url)}
+Thank you!
+`,
+  html: (user, url) => `Hello! 👋<br/>
+Click the following link to be automatically logged in:<br/><br/>
+${encodeSelector(url)}<br/>
+Thank you!
+`,
+};


### PR DESCRIPTION
<img width="521" alt="Screenshot 2022-08-30 at 11 33 27" src="https://user-images.githubusercontent.com/1092138/187407103-f76d83ac-1151-4ef9-ab88-9192c8af8515.png">
<img width="518" alt="Screenshot 2022-08-30 at 11 48 18" src="https://user-images.githubusercontent.com/1092138/187407148-a3184453-888e-4b2f-8ba9-b9bd6bbcb192.png">
<img width="431" alt="Screenshot 2022-08-30 at 10 16 41" src="https://user-images.githubusercontent.com/1092138/187407167-00a44fbd-5a78-4454-826c-0c26942bf568.png">

Use Meteor `accounts-passwordless` package to implement passwordless login.

When the setting `passwordless` is set to true, the password step is skipped during registration process.

During the login, the user only needs to provide his email and receives a link to be automatically logged-in.

The startup hook to auto login with query param token is required because the default `accounts-passwordless` implementation isn't compatible with the `accounts-guest` package.