### PR TITLE
Improve identifying analytics

### DIFF
--- a/core/server/accounts.js
+++ b/core/server/accounts.js
@@ -36,6 +36,7 @@ Accounts.onLogin(param => {
   }
 
   analytics.track(user._id, '👋 Sign In', { type: param.type });
+  analytics.identify(user);
 });
 
 Accounts.validateLoginAttempt(param => {

--- a/core/server/users.js
+++ b/core/server/users.js
@@ -79,7 +79,7 @@ Meteor.methods({
     completeUserProfile(Meteor.user(), email, name);
     Accounts.setPassword(this.userId, password, { logout: false });
 
-    analytics.createUser(Meteor.user());
+    analytics.identify(Meteor.user());
     analytics.track(this.userId, '🐣 Sign Up', { source });
   },
   teleportUserInLevel(levelId) {


### PR DESCRIPTION
As recommended by Segment documentation, identify is now also called at log-in.
(https://segment.com/docs/connections/spec/identify/)

Reserved and custom traits have now a more distinct separation as they are handled a bit differently by Segment ($ prefix or case handling for instance).
https://segment.com/docs/connections/spec/identify/#traits