### PR TITLE
WIP: split streams from peers + add methods to close peer calls

### DIFF
--- a/core/client/lemverse.js
+++ b/core/client/lemverse.js
@@ -177,12 +177,13 @@ Template.lemverse.onCreated(function () {
     if (!user) return;
     Tracker.nonreactive(() => {
       if (userProximitySensor.nearUsersCount() === 0) userStreams.destroyStream(streamTypes.main);
-      else if (!user.profile.shareVideo) userStreams.video(false);
-      else if (user.profile.shareVideo) {
+      else if (!user.profile.shareVideo) {
+        userStreams.video(false);
+      } else if (user.profile.shareVideo) {
         const forceNewStream = userStreams.shouldCreateNewStream(streamTypes.main, true, true);
         userStreams.createStream(forceNewStream).then(() => {
           userStreams.video(true);
-          userProximitySensor.callProximityStartedForAllNearUsers();
+          peer.call(Object.values(userProximitySensor.nearUsers));
         });
       }
 
@@ -201,9 +202,13 @@ Template.lemverse.onCreated(function () {
         if (user.profile.shareScreen) meet.shareScreen();
         else meet.unshareScreen();
       } else if (user.profile.shareScreen) {
-        userStreams.createScreenStream().then(() => userStreams.screen(true));
+        userStreams.createScreenStream().then(() => {
+          userStreams.screen(true);
+          peer.call(Object.values(userProximitySensor.nearUsers));
+        });
       } else {
         userStreams.screen(false);
+        peer.closePeerCalls(false, streamTypes.screen);
       }
     });
   });

--- a/core/client/user-streams.js
+++ b/core/client/user-streams.js
@@ -36,16 +36,10 @@ userStreams = {
 
   screen(enabled) {
     const { instance: screenStream } = this.streams.screen;
-    if (screenStream && !enabled) {
-      this.stopTracks(screenStream);
-      this.streams.screen.instance = undefined;
-      _.each(peer.calls, (call, key) => {
-        if (key.indexOf('-screen') === -1) return;
-        if (Meteor.user().options?.debug) log('me -> you screen ****** I stop sharing screen, call closing', key);
-        call.close();
-        delete peer.calls[key];
-      });
-    } else if (enabled) userProximitySensor.callProximityStartedForAllNearUsers();
+    if (!screenStream || enabled) return;
+
+    this.stopTracks(screenStream);
+    this.streams.screen.instance = undefined;
   },
 
   destroyStream(type) {


### PR DESCRIPTION
The purpose of this RP is to separate the stream creation logic from the communication logic. The idea is to be able to more easily launch a call with or without webcam and to easily manage the streams between users then renegotiate peer calls