### PR TITLE
Move sounds configuration to settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -365,7 +365,17 @@ Please note, that as stated in section `Deploy in production`, there is an addit
       "answerDelayBetweenAttempt": 750,
       "avatarAPI": "https://source.unsplash.com/320x240/?cat&sig=[user_id]", // Avatar when users do not share their camera
       "callDelay": 250, // Delay before a call is started, useful to avoid a call when you pass by someone
-      "delayBeforeClosingCall": 1000
+      "delayBeforeClosingCall": 1000,
+      "sounds": {
+        "hangUp": {
+          "file": "webrtc-out.mp3",
+          "volume": 0.2
+        },
+        "incomingCall": {
+          "file": "webrtc-in.mp3",
+          "volume": 0.2
+        }
+      }
     },
 
     "meet": {

--- a/app/_settings.json
+++ b/app/_settings.json
@@ -28,7 +28,17 @@
       "answerDelayBetweenAttempt": 750,
       "avatarAPI": "https://source.unsplash.com/320x240/?cat&sig=[user_id]",
       "callDelay": 250,
-      "delayBeforeClosingCall": 1000
+      "delayBeforeClosingCall": 1000,
+      "sounds": {
+        "hangUp": {
+          "file": "webrtc-out.mp3",
+          "volume": 0.2
+        },
+        "incomingCall": {
+          "file": "webrtc-in.mp3",
+          "volume": 0.2
+        }
+      }
     },
 
     "meet": {

--- a/app/settings-dev.json
+++ b/app/settings-dev.json
@@ -28,7 +28,17 @@
       "answerDelayBetweenAttempt": 750,
       "avatarAPI": "https://source.unsplash.com/320x240/?[user_avatar]&sig=[user_id]",
       "callDelay": 250,
-      "delayBeforeClosingCall": 1000
+      "delayBeforeClosingCall": 1000,
+      "sounds": {
+        "hangUp": {
+          "file": "webrtc-out.mp3",
+          "volume": 0.2
+        },
+        "incomingCall": {
+          "file": "webrtc-in.mp3",
+          "volume": 0.2
+        }
+      }
     },
 
     "meet": {

--- a/core/client/peer.js
+++ b/core/client/peer.js
@@ -135,7 +135,8 @@ peer = {
 
     if (!activeCallsCount) return;
 
-    audioManager.play('webrtc-out.mp3', 0.2);
+    const { file, volume } = Meteor.settings.public.peer.sounds.hangUp;
+    audioManager.play(file, volume);
   },
 
   close(userId, timeout = 0, origin = null) {
@@ -191,7 +192,8 @@ peer = {
     const { shareAudio, shareScreen, shareVideo } = Meteor.user().profile;
 
     if (!this.calls[`${user._id}-${streamTypes.main}`] && !this.calls[`${user._id}-${streamTypes.screen}`]) {
-      audioManager.play('webrtc-in.mp3', 0.2);
+      const { file, volume } = Meteor.settings.public.peer.sounds.incomingCall;
+      audioManager.play(file, volume);
       notify(user, `Wants to talk to you`);
 
       if (!this.callStartDates[user._id]) {


### PR DESCRIPTION
I moved the name of the sound files to be played on an incoming call or at the end of a call to a configuration file to remove the raw values from the code and be able to choose other sounds