### PR TITLE
Entity performance improvement

### DIFF
--- a/core/client/entity-manager.js
+++ b/core/client/entity-manager.js
@@ -174,7 +174,7 @@ entityManager = {
 
   postUpdate() {
     const { controlledCharacter } = userManager;
-    if (controlledCharacter?.wasMoving && !Meteor.user({ 'profile.guest': 1 }).profile.guest) this.handleNearestEntityTooltip(controlledCharacter);
+    if (controlledCharacter?.wasMoving) this.handleNearestEntityTooltip(controlledCharacter);
 
     Object.values(this.entities).forEach(entity => {
       const customDepth = entity.getData('customDepth');

--- a/core/client/entity-manager.js
+++ b/core/client/entity-manager.js
@@ -28,7 +28,6 @@ const entityTooltipConfig = {
   style: 'tooltip with-arrow fade-in',
 };
 
-const fixedUpdateInterval = 200;
 const entityCreatedThreshold = 1000; // In ms
 const floatingDistance = 20;
 const itemAddedToInventoryText = 'Item added to your inventory';
@@ -42,14 +41,11 @@ entityManager = {
 
   init(scene) {
     this.scene = scene;
-    this.fixedUpdateMethod = this._fixedUpdate.bind(this);
-    this.fixedUpdateInterval = setInterval(this.fixedUpdateMethod, fixedUpdateInterval);
   },
 
   destroy() {
     this.entities = {};
     this.previousNearestEntity = undefined;
-    clearInterval(this.fixedUpdateInterval);
   },
 
   onDocumentAdded(entity) {
@@ -181,7 +177,7 @@ entityManager = {
     if (userManager.controlledCharacter?.wasMoving) this.shouldCheckNearestEntity = true;
   },
 
-  _fixedUpdate() {
+  fixedUpdate() {
     const { controlledCharacter } = userManager;
     if (!controlledCharacter) return;
 

--- a/core/client/scenes/scene-world.js
+++ b/core/client/scenes/scene-world.js
@@ -3,6 +3,7 @@ import Phaser from 'phaser';
 
 import { clamp } from '../helpers';
 
+const fixedUpdateInterval = 200;
 const zoomConfig = Meteor.settings.public.zoom;
 
 const onZoneEntered = e => {
@@ -44,6 +45,7 @@ WorldScene = new Phaser.Class({
     this.resizeMethod = this.resize.bind(this);
     this.postUpdateMethod = this.postUpdate.bind(this);
     this.shutdownMethod = this.shutdown.bind(this);
+    this.fixedUpdateInterval = setInterval(() => this.fixedUpdate(), fixedUpdateInterval);
 
     // controls
     this.enableKeyboard(true, true);
@@ -116,9 +118,9 @@ WorldScene = new Phaser.Class({
     const pinchPlugin = this.plugins.get('rexpinchplugin').add(this);
 
     // Disable joystick to avoid user moving while zooming
-    pinchPlugin.on('pinchstart', function() {
-      const nipple = this.nippleManager.get(this.nippleManager.ids[0])
-      nipple.destroy()
+    pinchPlugin.on('pinchstart', function () {
+      const nipple = this.nippleManager.get(this.nippleManager.ids[0]);
+      nipple.destroy();
     }, this);
 
     pinchPlugin.on('pinch', function (pinch) {
@@ -141,6 +143,10 @@ WorldScene = new Phaser.Class({
     this.cameras.main.setRoundPixels(true);
     this.resetZoom();
     this.scene.setVisible(true);
+  },
+
+  _fixedUpdate() {
+    entityManager.fixedUpdate();
   },
 
   update() {
@@ -194,6 +200,7 @@ WorldScene = new Phaser.Class({
   shutdown() {
     this.nippleManager?.destroy();
 
+    clearInterval(this.fixedUpdateInterval);
     this.events.removeListener('postupdate');
     this.events.off('postupdate', this.postUpdateMethod, this);
     this.events.off('sleep', this.sleepMethod, this);

--- a/core/client/scenes/scene-world.js
+++ b/core/client/scenes/scene-world.js
@@ -45,7 +45,7 @@ WorldScene = new Phaser.Class({
     this.resizeMethod = this.resize.bind(this);
     this.postUpdateMethod = this.postUpdate.bind(this);
     this.shutdownMethod = this.shutdown.bind(this);
-    this.fixedUpdateInterval = setInterval(() => this.fixedUpdate(), fixedUpdateInterval);
+    this.fixedUpdateInterval = setInterval(() => this._fixedUpdate(), fixedUpdateInterval);
 
     // controls
     this.enableKeyboard(true, true);


### PR DESCRIPTION
The first (small) step in improving performance.

In most cases the simulation logic does not need to be run at 60 FPS (unlike rendering). In most game engines there are few update methods which not exists in web due to the `requestAnimationFrame` usage: 
- One for physics (depends on the project settings, usually 20 times per second)
- One for the rendering (60 times per second)
- One for the rest of the logic

The chrome profiler indicated that the detection of close entities was a bit greedy, by moving this logic in a function executed less often I decrease the CPU usage a little bit.