### PR TITLE
Fix relative popInConfiguration broken

### DIFF
--- a/core/client/character-pop-ins.js
+++ b/core/client/character-pop-ins.js
@@ -25,7 +25,7 @@ characterPopIns = {
   },
 
   initFromZone(zone) {
-    const config = zone.popInConfiguration || {};
+    const config = { ...zone.popInConfiguration } || {};
     if (config.position) {
       const position = zoneManager.computePositionFromString(zone, config.position);
       if (config.position === 'relative') {


### PR DESCRIPTION
Making shallow copy of popInConfiguration to avoid reference of `const config`. Actually, when we use `position: relative` on popInConfiguration. The `config.x` and `config.y` will be increment exponentially due to this copy of reference instead of shallow copy, because each time we reuse `const config`it will save the same value of previous iteration and increment it to the user position.