### PR TITLE
Rationalize settings template helpers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -108,3 +108,6 @@ dist
 
 # TernJS port file
 .tern-port
+
+# IntelliJ configuration files
+.idea

--- a/core/client/ui/form-log-in.hbs.html
+++ b/core/client/ui/form-log-in.hbs.html
@@ -28,7 +28,7 @@
             <input name="email" type="email" value="{{email}}" class="js-edit js-email" autofocus>
           </div>
           {{#if loginMode}}
-            {{#if passwordless}}
+            {{#if settings.public.passwordless}}
               <button type="submit" class="button submit" aria-label="send magic link email">Send</button>
             {{else}}
               <div class="group-field">

--- a/core/client/ui/form-log-in.js
+++ b/core/client/ui/form-log-in.js
@@ -107,7 +107,6 @@ Template.formLogIn.helpers({
   password() { return Template.instance().password; },
   loginMode() { return Template.instance().loginMode.get(); },
   contactURL() { return Meteor.settings.public.permissions?.contactURL; },
-  passwordless() { return Meteor.settings.public.passwordless; },
   emailSent() { return Template.instance().emailSent.get(); },
   counter() { return Template.instance().counter.get(); },
   canRetry() { return !!Template.instance().counter.get(); },

--- a/core/client/ui/form-sign-in.hbs.html
+++ b/core/client/ui/form-sign-in.hbs.html
@@ -46,7 +46,7 @@
             <input name="nickname" type="text" value="{{nickname}}" class="js-edit js-nickname">
           </div>
           <button type="submit" class="submit" aria-label="create my character">Create my character</button>
-          <p class="tos">By clicking "Create my character", you agree on <a href="{{termsLink}}" target="_blank" rel="noopener">Terms</a> and that you have read our <a href="{{privacyLink}}" target="_blank" rel="noopener">Data use policy</a>, including our <a href="{{cookiesLink}}" target="_blank" rel="noopener">Cookie use</a>.</p>
+          <p class="tos">By clicking "Create my character", you agree on <a href="{{settings.public.tos.termsLink}}" target="_blank" rel="noopener">Terms</a> and that you have read our <a href="{{settings.public.tos.privacy}}" target="_blank" rel="noopener">Data use policy</a>, including our <a href="{{settings.public.tos.cookies}}" target="_blank" rel="noopener">Cookie use</a>.</p>
         </form>
       </div>
     {{/if}}

--- a/core/client/ui/form-sign-in.js
+++ b/core/client/ui/form-sign-in.js
@@ -92,7 +92,4 @@ Template.formSignIn.helpers({
   nickname() { return Template.instance().nickname; },
   password() { return Template.instance().password; },
   getStep() { return Template.instance().step.get(); },
-  termsLink() { return Meteor.settings.public.tos.terms; },
-  cookiesLink() { return Meteor.settings.public.tos.cookies; },
-  privacyLink() { return Meteor.settings.public.tos.privacy; },
 });

--- a/core/client/ui/settings-main.hbs.html
+++ b/core/client/ui/settings-main.hbs.html
@@ -3,7 +3,7 @@
     <path d="M12,15.5A3.5,3.5 0 0,1 8.5,12A3.5,3.5 0 0,1 12,8.5A3.5,3.5 0 0,1 15.5,12A3.5,3.5 0 0,1 12,15.5M19.43,12.97C19.47,12.65 19.5,12.33 19.5,12C19.5,11.67 19.47,11.34 19.43,11L21.54,9.37C21.73,9.22 21.78,8.95 21.66,8.73L19.66,5.27C19.54,5.05 19.27,4.96 19.05,5.05L16.56,6.05C16.04,5.66 15.5,5.32 14.87,5.07L14.5,2.42C14.46,2.18 14.25,2 14,2H10C9.75,2 9.54,2.18 9.5,2.42L9.13,5.07C8.5,5.32 7.96,5.66 7.44,6.05L4.95,5.05C4.73,4.96 4.46,5.05 4.34,5.27L2.34,8.73C2.21,8.95 2.27,9.22 2.46,9.37L4.57,11C4.53,11.34 4.5,11.67 4.5,12C4.5,12.33 4.53,12.65 4.57,12.97L2.46,14.63C2.27,14.78 2.21,15.05 2.34,15.27L4.34,18.73C4.46,18.95 4.73,19.03 4.95,18.95L7.44,17.94C7.96,18.34 8.5,18.68 9.13,18.93L9.5,21.58C9.54,21.82 9.75,22 10,22H14C14.25,22 14.46,21.82 14.5,21.58L14.87,18.93C15.5,18.67 16.04,18.34 16.56,17.94L19.05,18.95C19.27,19.03 19.54,18.95 19.66,18.73L21.66,15.27C21.78,15.05 21.73,14.78 21.54,14.63L19.43,12.97Z" />
   </svg>
 </template>
-      
+
 <template name="settingsMain">
   {{#modal title="Settings"}}
     <div class="settings">
@@ -17,7 +17,7 @@
           </div>
         </h1>
         <ul class="menu-entries">
-          {{#if allowProfileEdition}}
+          {{#if settings.public.permissions.allowProfileEdition}}
             <li class="{{#if eq activePage "settingsBasic"}}selected{{/if}}">
               <button class="js-menu-entry button" data-page="settingsBasic">
                 <svg style="width:24px;height:24px" viewBox="0 0 24 24">
@@ -43,7 +43,7 @@
               <span class="text">Media settings</span>
             </button>
           </li>
-          {{#unless passwordless}}
+          {{#unless settings.public.passwordless}}
             <li class="{{#if eq activePage "settingsPassword"}}selected{{/if}}">
               <button class="js-menu-entry button" data-page="settingsPassword">
                 <svg style="width:24px;height:24px" viewBox="0 0 24 24">
@@ -53,9 +53,9 @@
               </button>
             </li>
           {{/unless}}
-          {{#if helpURL}}
+          {{#if settings.public.lp.helpURL}}
           <li class="{{#if eq activePage "settingsHelp"}}selected{{/if}}">
-            <a class="button" href="{{helpURL}}" target="_blank" rel="noopener">
+            <a class="button" href="{{settings.public.lp.helpURL}}" target="_blank" rel="noopener">
               <svg style="width:24px;height:24px" viewBox="0 0 24 24">
                   <path fill="currentColor" d="M11,18H13V16H11V18M12,2A10,10 0 0,0 2,12A10,10 0 0,0 12,22A10,10 0 0,0 22,12A10,10 0 0,0 12,2M12,20C7.59,20 4,16.41 4,12C4,7.59 7.59,4 12,4C16.41,4 20,7.59 20,12C20,16.41 16.41,20 12,20M12,6A4,4 0 0,0 8,10H10A2,2 0 0,1 12,8A2,2 0 0,1 14,10C14,12 11,11.75 11,15H13C13,12.75 16,12.5 16,10A4,4 0 0,0 12,6Z" />
               </svg>

--- a/core/client/ui/settings-main.js
+++ b/core/client/ui/settings-main.js
@@ -6,9 +6,6 @@ Template.settingsMain.onCreated(() => {
 
 Template.settingsMain.helpers({
   activePage() { return Session.get('activeSettingsPage') || getDefaultActivePage(); },
-  allowProfileEdition() { return Meteor.settings.public.permissions.allowProfileEdition; },
-  helpURL() { return Meteor.settings.public.lp.helpURL; },
-  passwordless() { return Meteor.settings.public.passwordless; },
 });
 
 Template.settingsMain.events({


### PR DESCRIPTION
Fixes #126 

I just searched for usages of `Meteor.settings...` as a helper and replaced them.
I only kept the `contactURL` helper because it shims the potential undefined `Meteor.settings.public.permissions` property. Maybe this should be replaced to?

I also realized that many helpers with `Template.instance()` exists and could be replaced with the global `instance` helper:
https://github.com/l3mpire/lemverse/blob/cf70039679d74fd4fc4ee17fcdabf1e1f25807f2/app/packages/lempire/lempire-helpers.js#L25

But just because these are much more (44 usages in 21 files), it should be done in a separate issue ☺️ 