### PR TITLE
Fixes #165: Make website in profile popup clickable link

### DIFF
--- a/core/client/ui/user-profile.hbs.html
+++ b/core/client/ui/user-profile.hbs.html
@@ -12,7 +12,11 @@
         </div>
         <div>
           <label for="website" class="label">Website</label>
-          {{or website "-"}}
+          {{#if website}}
+            <a target="_blank" class="website-link" href="{{website}}">{{website}}</a>
+          {{else}}
+            -
+          {{/if}}
         </div>
         <div>
           <label for="bio" class="label">Bio/Hobbies</label>

--- a/core/client/ui/user-profile.scss
+++ b/core/client/ui/user-profile.scss
@@ -76,4 +76,8 @@
     transform: translateX(-50%);
     width: 100%;
   }
+
+  .website-link{
+    color:cornflowerblue;
+  }
 }


### PR DESCRIPTION
Fixes #165 

Add feature for converting users website into a `clickable` link. 

if the user has no website, then it just shows a dash.

![image](https://user-images.githubusercontent.com/29176293/195733492-26ae522c-cc65-4750-935a-1621be40cb63.png)
