### PR TITLE
Play punched sound with a random pitch

### DIFF
--- a/core/client/audio-manager.js
+++ b/core/client/audio-manager.js
@@ -25,6 +25,31 @@ export default {
     audio.addEventListener('canplaythrough', audio.play);
   },
 
+  /**
+   * Play a sound with a specific pitch ratio.
+   * 1.0 is the original pitch, 0.5 is half the pitch, 2.0 is twice the pitch.
+   *
+   * @param {string} name The name of the audio file to play
+   * @param {number} pitch The pitch ratio to play the sound at
+   * @param {number} volume The volume to play the sound at
+   * @returns {Promise<void>}
+   */
+  async playPitched(name, pitch = 1.0, volume = 1.0) {
+    if (!name || !this.enabled) return;
+
+    const audioContext = new AudioContext();
+    const pitchedAudioBuffer = audioContext.createBufferSource();
+
+    const audioFileUrl = `${this.folder}${name}`;
+    const audioBuffer = await this.fetchAudioBuffer(audioFileUrl, audioContext);
+
+    pitchedAudioBuffer.buffer = audioBuffer;
+    pitchedAudioBuffer.volume = volume;
+    pitchedAudioBuffer.playbackRate.value = pitch;
+    pitchedAudioBuffer.connect(audioContext.destination);
+    pitchedAudioBuffer.start(0);
+  },
+
   createAudioURL(chunks) {
     const sound = this.generateBlob(chunks);
     const audioURL = URL.createObjectURL(sound);
@@ -63,5 +88,19 @@ export default {
     if (!supportedType) throw new Error('Unable to find a supported type');
 
     return supportedType;
+  },
+
+  /**
+   * Loads and returns the audio file as an AudioBuffer
+   *
+   * @param {string} url The url of the audio file
+   * @param {AudioContext} audioContext
+   * @returns {Promise<AudioBuffer>}
+   */
+  async fetchAudioBuffer(url, audioContext) {
+    const response = await fetch(url);
+    const buffer = await response.arrayBuffer();
+
+    return audioContext.decodeAudioData(buffer);
   },
 };

--- a/core/lib/misc.js
+++ b/core/lib/misc.js
@@ -20,7 +20,28 @@ const permissionTypes = Object.freeze({
 
 const defaultSpawnPosition = { x: 100, y: 100 };
 
+/**
+ * Returns a random integer in the range [min, max]
+ *
+ * @param {number} min
+ * @param {number} max
+ * @returns {number}
+ */
 const randomInRange = (min, max) => Math.floor(Math.random() * (max - min + 1)) + min;
+
+/**
+ * Returns a random float, capped to the given decimals, in the range [min, max]
+ *
+ * @param {number} min
+ * @param {number} max
+ * @param {number} decimals
+ * @returns {number}
+ */
+const randomFloatInRange = (min, max, decimals) =>
+  parseFloat(
+    (Math.random() * (max - min) + min)
+      .toFixed(decimals)
+  );
 
 const subscribedUsersToEntity = entityId => {
   check(entityId, Match.Id);
@@ -264,4 +285,6 @@ export {
   permissionTypes,
   subscribedUsersToEntity,
   teleportUserInLevel,
+  randomInRange,
+  randomFloatInRange,
 };

--- a/core/modules/punch-ability/client/punch-ability.js
+++ b/core/modules/punch-ability/client/punch-ability.js
@@ -1,8 +1,15 @@
 import audioManager from '../../../client/audio-manager';
 
+const getRandomFloat = (min, max, decimals) =>
+  parseFloat(
+    (Math.random() * (max - min) + min)
+      .toFixed(decimals)
+  );
+
 const playPunchAnimation = () => {
   userManager.scene.cameras.main.shake(250, 0.015, 0.02);
-  audioManager.play('punch.mp3');
+  const randomPitchRatio = getRandomFloat(0.7, 1.5, 1);
+  audioManager.playPitched('punch.mp3', randomPitchRatio);
 };
 
 const punch = users => {

--- a/core/modules/punch-ability/client/punch-ability.js
+++ b/core/modules/punch-ability/client/punch-ability.js
@@ -1,14 +1,9 @@
 import audioManager from '../../../client/audio-manager';
-
-const getRandomFloat = (min, max, decimals) =>
-  parseFloat(
-    (Math.random() * (max - min) + min)
-      .toFixed(decimals)
-  );
+import { randomFloatInRange } from '../../../lib/misc';
 
 const playPunchAnimation = () => {
   userManager.scene.cameras.main.shake(250, 0.015, 0.02);
-  const randomPitchRatio = getRandomFloat(0.7, 1.5, 1);
+  const randomPitchRatio = randomFloatInRange(0.7, 1.5, 1);
   audioManager.playPitched('punch.mp3', randomPitchRatio);
 };
 


### PR DESCRIPTION
Fixes #167

Updates the punch ability to play pitched with a random value between `0.7` and `1.5`.
This is only possible on an [`AudioBuffer`](https://developer.mozilla.org/en-US/docs/Web/API/AudioBuffer), that's why I had to add a method to load the audio buffer from the URL.

See attached video (with sound ;) )
https://user-images.githubusercontent.com/6061136/196361057-fe72ac74-c0e8-41cf-9bc0-c7ed39d4b574.mp4

