### PR TITLE
Fix logout errors

### DIFF
--- a/core/client/ui/settings-main.js
+++ b/core/client/ui/settings-main.js
@@ -13,9 +13,8 @@ Template.settingsMain.events({
     event.preventDefault();
     event.stopPropagation();
     lp.notif.confirm('Logout', `You will be disconnected from ${Meteor.settings.public.lp.product}, are you sure ?`, () => {
-      Meteor.logout(() => {
-        closeModal();
-      });
+      closeModal();
+      Meteor.logout();
     });
   },
   'click .js-menu-entry'(event) { Session.set('activeSettingsPage', event.currentTarget.dataset.page); },


### PR DESCRIPTION
During the logout there is a short lapse of time where Meteor.user() is null, if the logout is performed on character or media settings screen the reactive template helpers are called and throw errors.