### PR TITLE
Optimize tileset edition

### DIFF
--- a/core/client/ui/editor-tilesets.js
+++ b/core/client/ui/editor-tilesets.js
@@ -1,5 +1,12 @@
 zoom = 1.5;
-selectedTileset = () => Tilesets.findOne(Session.get('selectedTilesetId')) || {};
+const _selectedTileset = new ReactiveVar();
+selectedTileset = () => _selectedTileset.get();
+
+Tracker.autorun(() => {
+  const tilesetId = Session.get('selectedTilesetId');
+  if (!tilesetId) return;
+  _selectedTileset.set(Tilesets.findOne(tilesetId) || {});
+});
 
 Tracker.autorun(() => {
   const creating = Session.get('selectedEditTilesetId');
@@ -35,10 +42,6 @@ Template.registerHelper('zoom', (v, w) => zoom * v * w);
 
 Template.editorTilesets.onCreated(function () {
   this.subscribe('tilesets');
-
-  this.autorun(() => {
-    selectedTileset();
-  });
 
   hotkeys('p', event => {
     event.preventDefault();


### PR DESCRIPTION
When `selectedTileset()` is called in an handlebars template, a new cursor with an observer is created for each call (e.g `tile2domX`, `tile2domY`, etc), meaning that, for a large template, when a tileset is edited (for collision or layering), Meteor does literally thousands of local Minimongo updates of the tileset document copies, taking several seconds to perform.

This part might need a bigger refactoring but in the meanwhile I suggest this small optimization which allows to create a new observer only when the selected tileset changes.