### PR TITLE
Update user status in setUserInDoNotDisturbMode

### DIFF
--- a/core/client/user-manager.js
+++ b/core/client/user-manager.js
@@ -320,10 +320,12 @@ userManager = {
         'profile.shareAudio': false,
         'profile.shareScreen': false,
       } }), 0);
+      Meteor.call('user-status-idle');
       peer.disable();
     } else {
       peer.enable();
       this.clearMediaStates();
+      Meteor.call('user-status-active');
     }
 
     this.follow(undefined); // interrupts the follow action

--- a/core/server/users.js
+++ b/core/server/users.js
@@ -1,6 +1,6 @@
 import { completeUserProfile, getSpawnLevel, levelSpawnPosition, teleportUserInLevel } from '../lib/misc';
 
-const mainFields = { options: 1, profile: 1, roles: 1, status: { online: 1 }, beta: 1, guildId: 1 };
+const mainFields = { options: 1, profile: 1, roles: 1, status: { idle: 1, online: 1 }, beta: 1, guildId: 1 };
 
 Meteor.publish('users', function (levelId) {
   check(levelId, Match.Maybe(Match.Id));


### PR DESCRIPTION
Retrieves the user's status and updates it to inactive in the focus rooms. The purpose is to use this status to indicate when a user is not available
<img width="206" alt="Capture d’écran, le 2022-11-02 à 14 50 43" src="https://user-images.githubusercontent.com/3781087/199506740-a99b50cf-10e6-4313-89a0-d923e4753332.png">
