### PR TITLE
Use default value for the powerPreference flag

### DIFF
--- a/core/client/lemverse.js
+++ b/core/client/lemverse.js
@@ -42,7 +42,6 @@ const config = {
   },
   render: {
     pixelArt: true, // disable anti-aliasing & enable round pixels
-    powerPreference: 'low-power',
   },
   scale: {
     mode: Phaser.Scale.RESIZE,


### PR DESCRIPTION
I think this flag is not necessary anymore. In general when a simulation is visible one prefers to use the best available GPU in order to let the rest of the computer breathe. On some computers it should limit the CPU load and use the GPU (which will do much better)

"Provides a hint to the user agent as to which GPU configuration is suitable for this WebGL context. This can influence which GPU is used in a system with multiple GPUs. For example, a dual GPU system may have a GPU that consumes less power at the expense of rendering performance. Note that this property is only an indication and that a WebGL implementation may choose to ignore it.

WebGL implementations use context loss and restoration events to regulate power and memory consumption, regardless of the value of this attribute."

Source: https://registry.khronos.org/webgl/specs/latest/1.0/#5.2