### PR TITLE
Allow custom interactions on entities

### DIFF
--- a/core/client/helpers.js
+++ b/core/client/helpers.js
@@ -18,6 +18,8 @@ eventTypes = Object.freeze({
   onEntityAdded: 'onEntityAdded',
   onEntityUpdated: 'onEntityUpdated',
   onEntityRemoved: 'onEntityRemoved',
+  onEntityInteractionStarted: 'onEntityInteractionStarted',
+  onEntityInteractionStopped: 'onEntityInteractionStopped',
   onLevelLoaded: 'onLevelLoaded',
   onLevelLoading: 'onLevelLoading',
   onLevelUnloaded: 'onLevelUnloaded',

--- a/core/client/ui/toolboxes/entity-editor.hbs.html
+++ b/core/client/ui/toolboxes/entity-editor.hbs.html
@@ -21,7 +21,7 @@
       {{#if hasCustomAction}}
         <div class="entity-form-element">
           <label for="js-entity-target">Action</label>
-          <input type="text" id="js-entity-action" name="entity-action" value="{{entity.action}}">
+          <input type="text" id="js-entity-action" class="input" name="entity-action" value="{{entity.action}}">
         </div>
       {{else}}
         <div class="entity-form-element">

--- a/core/client/ui/toolboxes/entity-editor.hbs.html
+++ b/core/client/ui/toolboxes/entity-editor.hbs.html
@@ -18,15 +18,22 @@
     </div>
 
     {{#if isActionable}}
-      <div class="entity-form-element">
-        <label for="js-entity-target">Target</label>
-        <select name="entity-target" id="js-entity-target">
-          <option value="">-</option>
-            {{#each targets}}
-              <option value="{{_id}}" selected="{{eq _id entity.entityId}}">{{name}}</option>
-            {{/each}}
-        </select>
-      </div>
+      {{#if hasCustomAction}}
+        <div class="entity-form-element">
+          <label for="js-entity-target">Action</label>
+          <input type="text" id="js-entity-action" name="entity-action" value="{{entity.action}}">
+        </div>
+      {{else}}
+        <div class="entity-form-element">
+          <label for="js-entity-target">Target</label>
+          <select name="entity-target" id="js-entity-target">
+            <option value="">-</option>
+              {{#each targets}}
+                <option value="{{_id}}" selected="{{eq _id entity.entityId}}">{{name}}</option>
+              {{/each}}
+          </select>
+        </div>
+      {{/if}}
     {{/if}}
 
     {{#if hasSprite}}

--- a/core/client/ui/toolboxes/entity-editor.js
+++ b/core/client/ui/toolboxes/entity-editor.js
@@ -25,6 +25,13 @@ Template.entityEditor.events({
       closeInterface();
     });
   },
+  'input #js-entity-action'(event) {
+    const entity = selectedEntity();
+    if (!entity) return;
+
+    const { value } = event.target;
+    Entities.update(entity._id, { $set: { action: value } });
+  },
   'input #entity-depth'(event) {
     const entity = selectedEntity();
     if (!entity) return;
@@ -71,6 +78,7 @@ Template.entityEditor.helpers({
   flipped() { return selectedEntity()?.gameObject.scale < 0; },
   state() { return linkedEntity()?.state || selectedEntity()?.state; },
   targets() { return targets(); },
-  hasSprite() { return !!selectedEntity()?.gameObject?.sprite; },
-  isActionable() { return selectedEntity()?.actionType === entityActionType.actionable; },
+  hasSprite() { return Boolean(selectedEntity()?.gameObject?.sprite); },
+  isActionable() { return Boolean(selectedEntity()?.actionType === entityActionType.actionable); },
+  hasCustomAction() { return Boolean(selectedEntity()?.action); },
 });

--- a/core/client/ui/toolboxes/entity-editor.scss
+++ b/core/client/ui/toolboxes/entity-editor.scss
@@ -52,15 +52,20 @@
     flex-flow: wrap;
     align-items: center;
     min-height: 35px;
-
+    margin: 10px 0;
 
     label {
+      font-size: 0.85rem;
       width: 80px;
 
       &.entity-depth,
       &.entity-scale {
         width: 100%;
       }
+    }
+
+    input {
+      width: 100%;
     }
 
     select {

--- a/core/client/user-manager.js
+++ b/core/client/user-manager.js
@@ -270,6 +270,7 @@ userManager = {
     if (moving || this.controlledCharacter.wasMoving) {
       this.scene.physics.world.update(time, delta);
       networkManager.sendPlayerNewState(this.controlledCharacter);
+      this.stopInteracting();
     }
 
     if (!peer.hasActiveStreams()) peer.enableSensor(!(this.controlledCharacter.running && moving));
@@ -285,6 +286,10 @@ userManager = {
 
   interact() {
     entityManager.interactWithNearestEntity();
+  },
+
+  stopInteracting() {
+    entityManager.stopInteracting();
   },
 
   getPositionInFrontOfCharacter(character, distance = 0) {


### PR DESCRIPTION
Allows users to use entities other than to change a state from true to false. 

I've added the ability to open a URL like for zones. Unlike zones, the opening is not automatic, which is less intrusive. You just have to move to stop the interaction, I will add the "Escape" key later.

<img width="351" alt="Capture d’écran, le 2022-11-03 à 16 56 42" src="https://user-images.githubusercontent.com/3781087/199770844-a90134fa-78e1-41ad-9b8a-f11642e83702.png">

https://user-images.githubusercontent.com/3781087/199770968-c9841da2-8dc4-457f-a337-d4186335f00c.mov

