### PR TITLE
Add JWT user login

### DIFF
--- a/README.md
+++ b/README.md
@@ -534,6 +534,16 @@ Please note, that as stated in section `Deploy in production`, there is an addit
     "from": "The lembot <contact@domain.com>"
   },
 
+  "jwtAuthSecret": "your-256-bit-secret", // If specified, it allows user login using JWT
+  // For instance: https://app.lemverse.com?token={jwt_token}
+  // Example of the token payload:
+  // {
+  //   "sub": "user@example.com",
+  //   "nbf": 1667563200,
+  //   "exp": 1667570400,
+  //   "level_id": "lvl_nENCytZvbcHhxsFSt"
+  // }
+
   "meet": {
     "enableAuth": false
   },

--- a/core/client/passwordless.js
+++ b/core/client/passwordless.js
@@ -11,21 +11,31 @@ const checkToken = ({ selector, token }) => {
   });
 };
 
+const checkJWT = jwt => {
+  if (!jwt) return;
+  Accounts.callLoginMethod({
+    methodArguments: [{ jwt }],
+    userCallback: err => {
+      if (err) {
+        lp.notif.error(err.message);
+        throw err;
+      }
+    },
+  });
+};
+
 /**
  * Parse querystring for token argument, if found use it to auto-login
  */
 Accounts.autoLoginWithToken = function () {
-  Meteor.startup(() => {
-    const params = new URL(window.location.href).searchParams;
+  const params = new URL(window.location.href).searchParams;
 
-    if (params.get('loginToken')) {
-      checkToken({
-        selector: params.get('selector'),
-        token: params.get('loginToken'),
-      });
-    }
-  });
+  if (params.get('loginToken')) {
+    checkToken({
+      selector: params.get('selector'),
+      token: params.get('loginToken'),
+    });
+  } else if (params.get('token')) {
+    checkJWT(params.get('token'));
+  }
 };
-
-// Run check for login token on page load
-Meteor.startup(() => Accounts.autoLoginWithToken());


### PR DESCRIPTION
Allow users to login using a JWT provided in query param.

For instance: `https://app.lemverse.com?token={jwt_token}`
The minimal required payload is the user email in the `sub` claim:
```json
{
  "sub": "user@example.com"
}
```

Additional standard claims can be used (for instance to limit the token validity in a time range):
```json
{
  "sub": "user@example.com",
  "nbf": 1667563200,
  "exp": 1667570400,
}
```

and a custom `level_id` claim allows to log-in a user in a specific level:
```json
{
  "sub": "user@example.com",
  "level_id": "lvl_nENCytZvbcHhxsFSt"
}
```

When `"jwtAuthSecret"` is not provided in the settings, the JWT login handler is completely disabled.

This feature allows to generate time ranged login links from a third party app.

