### PR TITLE
Entities: show all non-pickable entities in the target list

### DIFF
--- a/core/client/ui/toolboxes/entity-editor.js
+++ b/core/client/ui/toolboxes/entity-editor.js
@@ -8,7 +8,7 @@ const selectedEntity = () => Entities.findOne(Session.get('selectedEntityId'));
 const linkedEntity = () => Entities.findOne({ _id: selectedEntity()?.entityId });
 const targets = () => {
   const activeEntityId = Session.get('selectedEntityId');
-  return Entities.find({ _id: { $ne: activeEntityId }, actionType: entityActionType.none }).fetch();
+  return Entities.find({ _id: { $ne: activeEntityId }, actionType: { $ne: entityActionType.pickable } }).fetch();
 };
 
 Template.entityEditor.events({


### PR DESCRIPTION
Allows level editors to link a switch to any type of entity that cannot be collected