### PR TITLE
Messages: split console state from the message module

### DIFF
--- a/core/modules/console/client/console.hbs.html
+++ b/core/modules/console/client/console.hbs.html
@@ -1,5 +1,5 @@
 <template name="console">
-  <div class="console">
+  <div class="console {{#if show}}show{{/if}}">
     <form class="js-console-form">
       <input type="file" tabindex="1" name="file" id="console-file" class="console-file" accept="image/png, image/jpeg, image/gif" />
       <label for="console-file">📎</label>

--- a/core/modules/console/client/console.js
+++ b/core/modules/console/client/console.js
@@ -45,6 +45,7 @@ openConsole = (autoSelectChannel = false) => {
   if (autoSelectChannel) messagesModule.autoSelectChannel();
   clearInputFields(true);
   Session.set('console', true);
+  Session.set('messagesUI', true);
   toggleUIInputs(true);
 
   return true;
@@ -128,6 +129,10 @@ Template.console.onDestroyed(() => {
   Session.set('console', false);
   document.removeEventListener('keydown', onKeyPressed);
   document.removeEventListener('paste', onPasteAction);
+});
+
+Template.console.helpers({
+  show() { return Session.get('console'); },
 });
 
 Template.console.events({

--- a/core/modules/console/client/console.scss
+++ b/core/modules/console/client/console.scss
@@ -11,6 +11,14 @@ $button-text-color: white;
   width: 100%;
   z-index: 100;
   overflow: hidden;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.25s linear;
+
+  &.show {
+    opacity: 1;
+    pointer-events: all;
+  }
 
   form {
     display: flex;

--- a/core/modules/messages/client/helpers.js
+++ b/core/modules/messages/client/helpers.js
@@ -32,7 +32,7 @@ const formatText = text => {
   return finalText.replace(/(?:\r\n|\r|\n)/g, '<br>');
 };
 
-const show = () => Session.get('message-module');
+const show = () => Session.get('messagesUI');
 
 export {
   getCurrentChannelName,

--- a/core/modules/messages/client/messages-list.hbs.html
+++ b/core/modules/messages/client/messages-list.hbs.html
@@ -40,7 +40,7 @@
 </template>
 
 <template name="messagesList">
-  <div class="messages-module">
+  <div class="messages-module {{#if show}}show{{/if}}">
     <h3 class="channel-name">{{channelName}}</h3>
     <button type="button" class="js-message-list-close" title="Close" tabindex="15">
       <span class="simple-modal-close__text">✖</span>

--- a/core/modules/messages/client/messages-list.js
+++ b/core/modules/messages/client/messages-list.js
@@ -82,7 +82,15 @@ Template.messagesList.onCreated(function () {
   this.fileSubscribeHandler = undefined;
 
   this.autorun(() => {
-    if (!Session.get('console')) {
+    if (Session.get('console')) return;
+
+    Tracker.nonreactive(() => {
+      Session.set('messagesUI', false);
+    });
+  });
+
+  this.autorun(() => {
+    if (!Session.get('messagesUI')) {
       this.fileSubscribeHandler?.stop();
       this.userSubscribeHandler?.stop();
       messagesModule.stopListeningMessagesChannel();

--- a/core/modules/messages/client/messages-list.js
+++ b/core/modules/messages/client/messages-list.js
@@ -78,6 +78,7 @@ Template.messagesListMessage.events({
 });
 
 Template.messagesList.onCreated(function () {
+  Session.set('messagesUI', false);
   this.userSubscribeHandler = undefined;
   this.fileSubscribeHandler = undefined;
 

--- a/core/modules/messages/client/messages-list.scss
+++ b/core/modules/messages/client/messages-list.scss
@@ -7,6 +7,14 @@
   overflow: hidden;
   background-color: rgba($main-color, 0.95);
   border-radius: $radius $radius 0 0;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.25s linear;
+
+  &.show {
+    opacity: 1;
+    pointer-events: all;
+  }
 
   .channel-name {
     margin: 0;
@@ -31,6 +39,7 @@
     line-height: 1;
     opacity: 0.8;
     color: white;
+    z-index: 10;
 
     &:hover {
       opacity: 1;

--- a/core/modules/textual-communication-tools/client/textual-communication-tools.scss
+++ b/core/modules/textual-communication-tools/client/textual-communication-tools.scss
@@ -12,9 +12,7 @@
   flex-direction: row;
   align-items: stretch;
   z-index: 100;
-  pointer-events: none;
-  opacity: 0;
-  transition: opacity 0.25s linear;
+  opacity: 1;
 
   .right-content {
     position: relative;
@@ -22,7 +20,6 @@
   }
 
   &.show {
-    opacity: 1;
-    pointer-events: all;
+    
   }
 }

--- a/core/modules/textual-communication-tools/client/textual-communication-tools.scss
+++ b/core/modules/textual-communication-tools/client/textual-communication-tools.scss
@@ -13,6 +13,7 @@
   align-items: stretch;
   z-index: 100;
   opacity: 1;
+  pointer-events: none;
 
   .right-content {
     position: relative;
@@ -20,6 +21,8 @@
   }
 
   &.show {
-    
+    > * {
+      pointer-events: all;
+    }
   }
 }


### PR DESCRIPTION
Separates the display logic of the messages module from the console. This will allow to customize the console interface or to use the console in a different way (launch commands for example)