### PR TITLE
Use level spawn position when switching level

### DIFF
--- a/core/client/ui/levels.js
+++ b/core/client/ui/levels.js
@@ -1,4 +1,4 @@
-import { isLevelOwner } from '../../lib/misc';
+import { isLevelOwner, teleportUserInLevel } from '../../lib/misc';
 
 const listMode = 'list';
 
@@ -19,7 +19,7 @@ const askLoadLevel = (levelId, incrementVisit = false) => {
     const data = { userId: Meteor.userId(), levelId, type: 'load-level' };
     window.parent.document.dispatchEvent(new CustomEvent(eventTypes.onPopInEvent, { detail: data }));
   } else {
-    Meteor.users.update(Meteor.userId(), { $set: { 'profile.levelId': levelId } });
+    teleportUserInLevel(Meteor.user(), Levels.findOne(levelId), 'load-level');
   }
 };
 

--- a/core/server/levels.js
+++ b/core/server/levels.js
@@ -169,7 +169,7 @@ deleteLevel = levelId => {
 Meteor.publish('levels', function () {
   if (!this.userId) return undefined;
 
-  return Levels.find({ }, { fields: { name: 1, hide: 1, visit: 1, createdBy: 1, template: 1 } });
+  return Levels.find({ }, { fields: { name: 1, hide: 1, visit: 1, createdBy: 1, template: 1, spawn: 1 } });
 });
 
 Meteor.publish('levelTemplates', function () {


### PR DESCRIPTION
This fix a "bug", when switching level, we use the user current position to the next level and sometime we can spawn in a wall, making the user blocked and can't moove.