### PR TITLE
Fix broken tilesets

### DIFF
--- a/core/client/ui/editor-tilesets.js
+++ b/core/client/ui/editor-tilesets.js
@@ -30,7 +30,7 @@ Template.registerHelper('tile2domY', index => {
 });
 
 Template.registerHelper('tilesets', () => {
-  const filters = { hidden: { $exists: false } };
+  const filters = { hidden: { $ne: true } };
   if (Meteor.user()?.roles?.admin) delete filters.hidden;
 
   return Tilesets.find(filters, { sort: { name: 1 } });

--- a/core/client/ui/toolboxes/tileset-toolbox.js
+++ b/core/client/ui/toolboxes/tileset-toolbox.js
@@ -83,7 +83,7 @@ Template.tilesetToolbox.onCreated(() => {
   bindKeyboardShortcuts();
 
   if (!Session.get('selectedTilesetId')) {
-    const firstTileset = Tilesets.findOne({ hidden: { $exists: false } }, { sort: { name: 1 } });
+    const firstTileset = Tilesets.findOne({ hidden: { $ne: true } }, { sort: { name: 1 } });
     Session.set('selectedTilesetId', firstTileset);
   }
 });


### PR DESCRIPTION
When tilesets has value `hidden: false` it was considered as hidden because we are checking if value exist and not if it's false. 