### PR TITLE
Fix call not closing when passing to fast near user

### DIFF
--- a/core/client/helpers.js
+++ b/core/client/helpers.js
@@ -251,7 +251,9 @@ const canAnswerCall = user => {
   if (userProximitySensor.isUserNear(user)) return true;
 
   const callDistanceThreshold = Meteor.settings.public.character.callDistanceThreshold || 300;
-  return userProximitySensor.distance(Meteor.user(), user) <= callDistanceThreshold;
+  const otherUser = Meteor.users.findOne(user._id, { fields: { 'profile.x': 1, 'profile.x': 1 }})
+
+  return userProximitySensor.distance(Meteor.user(), otherUser) <= callDistanceThreshold;
 };
 
 const toggleUIInputs = value => {


### PR DESCRIPTION
Actually, if you pass to fast near user, sometimes the connection can stay open. This is due to the way we check the distance between the users. We pass a user object between all function in the process and when finally we check if we have to keep the connection open, the user may have already moved but we have the default value when the process began. 

The fix is really simple, just fetching the user current position when we need to check the distances between them.