### PR TITLE
Add a setting to disable form login

### DIFF
--- a/README.md
+++ b/README.md
@@ -410,6 +410,7 @@ Please note, that as stated in section `Deploy in production`, there is an addit
       "allowAccountCreation": "all", // all for everyone, none for no-one, except:lvl_xxx to block a level
       "allowLevelCreation": true,
       "allowProfileEdition": true, // Shows 'My account' tab in the user settings menu
+      "allowFormLogin": true, // Disable to only allow JWT login (make sure to configure 'jwtAuthSecret' in this case)
       "contactURL": ""
     },
 

--- a/app/_settings.json
+++ b/app/_settings.json
@@ -160,6 +160,7 @@
       "allowAccountCreation": "all",
       "allowLevelCreation": true,
       "allowProfileEdition": true,
+      "allowFormLogin": true,
       "contactURL": ""
     },
 

--- a/app/settings-dev.json
+++ b/app/settings-dev.json
@@ -75,6 +75,7 @@
       "allowAccountCreation": "all",
       "allowLevelCreation": true,
       "allowProfileEdition": true,
+      "allowFormLogin": true,
       "contactURL": "",
       "guest": {
         "changeSkin": false,

--- a/core/client/lemverse.hbs.html
+++ b/core/client/lemverse.hbs.html
@@ -18,7 +18,7 @@
       </div>
     </div>
 
-    {{#if and guest (not onboarding)}}
+    {{#if and (and guest (not onboarding)) allowFormLogin}}
       {{> formAccount visible=loading}}
     {{else if onboarding}}
       {{> userOnboarding}}

--- a/core/client/lemverse.js
+++ b/core/client/lemverse.js
@@ -470,6 +470,7 @@ Template.lemverse.helpers({
   mainModules: () => Session.get('mainModules'),
   gameModules: () => Session.get('gameModules'),
   displayNotificationButton: () => (Meteor.settings.public.features?.notificationButton?.enabled !== false),
+  allowFormLogin: () => (Meteor.settings.public.permissions?.allowFormLogin !== false)
 });
 
 Template.lemverse.events({

--- a/core/server/accounts.js
+++ b/core/server/accounts.js
@@ -42,8 +42,13 @@ Accounts.onLogin(param => {
 });
 
 Accounts.validateLoginAttempt(param => {
-  const { user, methodName } = param;
+  const { user, methodName, type } = param;
   log('validateLoginAttempt: start', { type: param.type, allowed: param.allowed, methodName, username: param.methodArguments?.[0].user?.username, error: param.error, connection: param.connection, userId: user?._id });
+ 
+  if (Meteor.settings.public.permissions?.allowFormLogin === false && !(['jwt', 'resume', 'guest'].includes(type))) {
+    error(`validateLoginAttempt: ${type} login is disabled`);
+    return false;
+  }
 
   if (Meteor.settings.forbiddenIPs?.includes(lp.ip(param).ip)) {
     error('validateLoginAttempt: watched ip detected!', { ip: lp.ip(param).ip, userId: user?._id });


### PR DESCRIPTION
When form login is disabled, a user can only login to his account using a JWT. Resuming and guest login are still allowed.
If the setting is not provided nothing is changed (form login is disabled only when `allowFormLogin` is false).