### PR TITLE
Add map on entity depth

### DIFF
--- a/core/client/ui/toolboxes/entity-editor.hbs.html
+++ b/core/client/ui/toolboxes/entity-editor.hbs.html
@@ -39,7 +39,7 @@
     {{#if hasSprite}}
       <div class="entity-form-element">
         <label class="entity-depth" for="entity-depth">Depth</label>
-        <input type="range" id="entity-depth" name="depth" min="-1" max="1000" step="1" value="{{entity.gameObject.depth}}">
+        <input type="range" id="entity-depth" name="depth" min="-1" max="9" step="1" value="{{entity.gameObject.depth}}">
         <button type="button" data-type="depth" class="button secondary js-reset-attribute">Reset</button>
       </div>
 

--- a/core/client/ui/toolboxes/entity-editor.js
+++ b/core/client/ui/toolboxes/entity-editor.js
@@ -1,7 +1,8 @@
 import { clamp, toggleUIInputs } from '../../helpers';
 
 const entityMaxScale = 3;
-const entityDepthRange = { min: -1, max: 1000 };
+const entityDepthRange = { min: -1, max: 9 };
+const layerOffset = 10000 - 6; // 6 default value is equal to 10000, all layers > 5 are offset by 10000 - 5
 
 const closeInterface = () => Session.set('selectedEntityId', undefined);
 const selectedEntity = () => Entities.findOne(Session.get('selectedEntityId'));
@@ -36,8 +37,10 @@ Template.entityEditor.events({
     const entity = selectedEntity();
     if (!entity) return;
 
-    const { valueAsNumber: value } = event.target;
-    Entities.update(entity._id, { $set: { 'gameObject.depth': clamp(value, entityDepthRange.min, entityDepthRange.max) } });
+    var { valueAsNumber: value } = event.target;
+    if (value >= 6) value += layerOffset;
+
+    Entities.update(entity._id, { $set: { 'gameObject.depth': clamp(value, entityDepthRange.min, entityDepthRange.max + layerOffset) } });
   },
   'input #entity-scale'(event) {
     const entity = selectedEntity();


### PR DESCRIPTION
This pull request adds the posibility so set the depth of the entities above layer 6.

![image](https://user-images.githubusercontent.com/34689945/203572574-f4ae4244-a466-4ac9-b444-378ce7ff6593.png)
![image](https://user-images.githubusercontent.com/34689945/203572631-f89d0e82-1197-4b8e-923b-f5936dce709c.png)