### PR TITLE
Add fallback on remote user's avatar& add reactivity on the avatar

### DIFF
--- a/app/_settings.json
+++ b/app/_settings.json
@@ -12,6 +12,8 @@
       "enableOnboarding": false
     },
 
+    "avatarFallback": "lemverse.png",
+
     "debug": false,
 
     "defaultReaction": "❤️",

--- a/app/settings-dev.json
+++ b/app/settings-dev.json
@@ -14,6 +14,8 @@
       "faviconURL": "https://assets.website-files.com/62b4ba92180b4210cc065959/62bdafd68a5ffb164edbdf51_Favicon%20(1).png"
     },
 
+    "avatarFallback": "lemverse.png",
+
     "debug": false,
 
     "defaultReaction": "❤️",

--- a/core/client/lemverse.js
+++ b/core/client/lemverse.js
@@ -216,6 +216,7 @@ Template.lemverse.onCreated(function () {
       } else if (user.profile.shareScreen) {
         await userStreams.createScreenStream();
         userStreams.screen(true);
+        userProximitySensor.callProximityStartedForAllNearUsers();
       } else {
         userStreams.screen(false);
       }

--- a/core/client/lemverse.js
+++ b/core/client/lemverse.js
@@ -169,14 +169,12 @@ Template.lemverse.onCreated(function () {
   this.autorun(() => {
     const user = Meteor.user({ fields: { 'profile.shareAudio': 1 } });
     if (!user) return;
-    Tracker.nonreactive(() => {
+    Tracker.nonreactive(async () => {
       if (userProximitySensor.nearUsersCount() === 0) userStreams.destroyStream(streamTypes.main);
       else if (!user.profile.shareAudio) userStreams.audio(false);
       else if (user.profile.shareAudio) {
-        userStreams.createStream().then(() => {
-          userStreams.audio(true);
-          userProximitySensor.callProximityStartedForAllNearUsers();
-        });
+        await userStreams.createStream();
+        userProximitySensor.callProximityStartedForAllNearUsers();
       }
 
       if (meetingRoom.isOpen()) {
@@ -190,15 +188,13 @@ Template.lemverse.onCreated(function () {
   this.autorun(() => {
     const user = Meteor.user({ fields: { 'profile.shareVideo': 1 } });
     if (!user) return;
-    Tracker.nonreactive(() => {
+    Tracker.nonreactive(async () => {
       if (userProximitySensor.nearUsersCount() === 0) userStreams.destroyStream(streamTypes.main);
       else if (!user.profile.shareVideo) userStreams.video(false);
       else if (user.profile.shareVideo) {
         const forceNewStream = userStreams.shouldCreateNewStream(streamTypes.main, true, true);
-        userStreams.createStream(forceNewStream).then(() => {
-          userStreams.video(true);
-          userProximitySensor.callProximityStartedForAllNearUsers();
-        });
+        await userStreams.createStream(forceNewStream);
+        userProximitySensor.callProximityStartedForAllNearUsers();
       }
 
       if (meetingRoom.isOpen()) {
@@ -212,13 +208,14 @@ Template.lemverse.onCreated(function () {
   this.autorun(() => {
     const user = Meteor.user({ fields: { 'profile.shareScreen': 1 } });
     if (!user) return;
-    Tracker.nonreactive(() => {
+    Tracker.nonreactive(async () => {
       if (meetingRoom.isOpen()) {
         const meetingRoomService = meetingRoom.getMeetingRoomService();
         if (user.profile.shareScreen) meetingRoomService.shareScreen();
         else meetingRoomService.unshareScreen();
       } else if (user.profile.shareScreen) {
-        userStreams.createScreenStream().then(() => userStreams.screen(true));
+        await userStreams.createScreenStream();
+        userStreams.screen(true);
       } else {
         userStreams.screen(false);
       }

--- a/core/client/peer.js
+++ b/core/client/peer.js
@@ -369,8 +369,6 @@ peer = {
     if (!streamsByUsers.find(usr => usr._id === user._id)) {
       streamsByUsers.push({
         _id: user._id,
-        name: user.profile.name,
-        avatar: generateRandomAvatarURLForUser(user),
         main: {},
         screen: {},
         waitingCallAnswer: true,

--- a/core/client/peer.js
+++ b/core/client/peer.js
@@ -487,7 +487,7 @@ peer = {
     const { port, url: host, path, config } = result;
 
     const peerConfig = {
-      debug: Meteor.user().options?.debug ? 2 : 0,
+      debug: user.options?.debug ? 2 : 0,
       host,
       port,
       path,
@@ -496,7 +496,7 @@ peer = {
 
     if (skipConfig) delete peerConfig.config;
     if (this.peerInstance) this.destroy();
-    this.peerInstance = new Peer(Meteor.userId(), peerConfig);
+    this.peerInstance = new Peer(user._id, peerConfig);
     this.peerLoading = false;
 
     debug(`createMyPeer: created`, { peerInstanceId: this.peerInstance.id });

--- a/core/client/ui/remote-stream.hbs.html
+++ b/core/client/ui/remote-stream.hbs.html
@@ -1,7 +1,7 @@
 <template name="remoteStream">
-  <div class="stream js-video-{{remoteUser._id}} {{#if isTalking}}talking{{/if}}" data-state="{{state}}">
+  <div class="stream js-video-{{remoteUser._id}}" data-state="{{state}}">
     <div class="stream-name">
-        {{remoteUser.name}}
+        {{name}}
     </div>
     <div class="js-webcam webcam">
       {{#unless mediaState.shareAudio}}
@@ -11,15 +11,15 @@
         </div>
       {{/unless}}
       {{#unless mediaState.shareVideo}}
-        <img src={{remoteUser.avatar}} alt="avatar">
+        <img src="{{avatar}}" alt="avatar" class="avatar">
       {{/unless}}
       {{#if hasMainStream}}
-        {{> webcam triggerVar=talkingVar remoteUser=remoteUser}}
+        {{> webcam remoteUser=remoteUser}}
       {{/if}}
     </div>
     {{#if hasScreenStream}}
       <div class="js-screenshare screenshare">
-        {{> screenshare triggerVar=talkingVar remoteUser=remoteUser}}
+        {{> screenshare remoteUser=remoteUser}}
       </div>
     {{/if}}
   </div>

--- a/core/client/ui/settings-medias.js
+++ b/core/client/ui/settings-medias.js
@@ -1,3 +1,5 @@
+const screenShareDefaultFrameRate = 5;
+
 const updateSettingsStream = async template => {
   const constraints = userStreams.getStreamConstraints(streamTypes.main);
   constraints.forceNew = true;
@@ -5,10 +7,9 @@ const updateSettingsStream = async template => {
   const stream = await userStreams.requestUserMedia(constraints);
   if (!stream) { lp.notif.error(`unable to get a valid stream`); return; }
 
-  userStreams.enumerateDevices().then(({ mics, cams }) => {
-    template.audioRecorders.set(mics);
-    template.videoRecorders.set(cams);
-  });
+  const { mics, cams } = await userStreams.enumerateDevices();
+  template.audioRecorders.set(mics);
+  template.videoRecorders.set(cams);
 
   const video = document.querySelector('#js-video-preview');
   video.srcObject = stream;
@@ -50,7 +51,7 @@ Template.settingsMedias.events({
 });
 
 Template.settingsMedias.helpers({
-  frameRate() { return Meteor.user().profile.screenShareFrameRate || 22; },
+  frameRate() { return Meteor.user({ 'profile.screenShareFrameRate': 1 }).profile.screenShareFrameRate || screenShareDefaultFrameRate; },
   audioRecorders() { return Template.instance().audioRecorders.get(); },
   videoRecorders() { return Template.instance().videoRecorders.get(); },
 });

--- a/core/client/ui/settings-medias.js
+++ b/core/client/ui/settings-medias.js
@@ -1,4 +1,4 @@
-const screenShareDefaultFrameRate = 5;
+import { screenShareDefaultConfig } from '../user-streams';
 
 const updateSettingsStream = async template => {
   const constraints = userStreams.getStreamConstraints(streamTypes.main);
@@ -51,7 +51,7 @@ Template.settingsMedias.events({
 });
 
 Template.settingsMedias.helpers({
-  frameRate() { return Meteor.user({ 'profile.screenShareFrameRate': 1 }).profile.screenShareFrameRate || screenShareDefaultFrameRate; },
+  frameRate() { return Meteor.user({ 'profile.screenShareFrameRate': 1 }).profile.screenShareFrameRate || screenShareDefaultConfig.defaultFrameRate; },
   audioRecorders() { return Template.instance().audioRecorders.get(); },
   videoRecorders() { return Template.instance().videoRecorders.get(); },
 });

--- a/core/client/user-streams.js
+++ b/core/client/user-streams.js
@@ -242,3 +242,8 @@ userStreams = {
     return { mics, cams };
   },
 };
+
+export {
+  screenShareDefaultConfig,
+  videoDefaultConfig,
+};

--- a/core/client/user-streams.js
+++ b/core/client/user-streams.js
@@ -229,28 +229,6 @@ userStreams = {
     return false;
   },
 
-  generateFakeMediaStream() {
-    const silence = () => {
-      const ctx = new AudioContext();
-      const oscillator = ctx.createOscillator();
-      const dst = oscillator.connect(ctx.createMediaStreamDestination());
-      oscillator.start();
-
-      return Object.assign(dst.stream.getAudioTracks()[0], { enabled: false });
-    };
-
-    const black = ({ width = 280, height = 180 } = {}) => {
-      const canvas = Object.assign(document.createElement('canvas'), { width, height });
-      const context = canvas.getContext('2d');
-      context.fillRect(0, 0, width, height);
-
-      const stream = canvas.captureStream();
-      return Object.assign(stream.getVideoTracks()[0], { enabled: true });
-    };
-
-    return new MediaStream([black(), silence()]);
-  },
-
   async enumerateDevices() {
     const devices = await navigator.mediaDevices.enumerateDevices();
 

--- a/core/client/user-streams.js
+++ b/core/client/user-streams.js
@@ -9,6 +9,11 @@ const videoDefaultConfig = {
   frameRate: { ideal: 20 },
 };
 
+const debug = (text, meta) => {
+  if (!Meteor.user({ fields: { 'options.debug': 1 } })?.options?.debug) return;
+  log(text, meta);
+};
+
 streamTypes = Object.freeze({
   main: 'main',
   screen: 'screen',
@@ -39,21 +44,20 @@ userStreams = {
     if (screenStream && !enabled) {
       this.stopTracks(screenStream);
       this.streams.screen.instance = undefined;
-      _.each(peer.calls, (call, key) => {
+      Object.entries(peer.calls).forEach(([key, call]) => {
         if (key.indexOf('-screen') === -1) return;
-        if (Meteor.user().options?.debug) log('me -> you screen ****** I stop sharing screen, call closing', key);
+        debug('me -> you screen ****** I stop sharing screen, call closing', key);
         call.close();
         delete peer.calls[key];
       });
-    } else if (enabled) userProximitySensor.callProximityStartedForAllNearUsers();
+    }
   },
 
   destroyStream(type) {
-    const debug = Meteor.user()?.options?.debug;
     const { instance: stream } = type === streamTypes.main ? this.streams.main : this.streams.screen;
-    if (debug) log('destroyStream: start', { stream, type });
+    debug('destroyStream: start', { stream, type });
     if (!stream) {
-      if (debug) log('destroyStream: cancelled (stream was not alive)');
+      debug('destroyStream: cancelled (stream was not alive)');
       return;
     }
 
@@ -64,20 +68,18 @@ userStreams = {
   },
 
   async requestUserMedia(constraints = {}) {
-    const debug = Meteor.user().options?.debug;
-
-    if (debug) log('requestUserMedia: start', { constraints });
+    debug('requestUserMedia: start', { constraints });
     if (constraints.forceNew) this.destroyStream(streamTypes.main);
 
     const { instance: currentStream, loading } = this.streams.main;
     if (currentStream) {
-      if (debug) log('requestUserMedia: stream already active');
+      debug('requestUserMedia: stream already active');
       return currentStream;
     }
 
     if (!currentStream && loading) {
       try {
-        if (debug) log('requestUserMedia: waiting existing stream to load…');
+        debug('requestUserMedia: waiting existing stream to load…');
         await waitFor(() => this.streams.main.instance !== undefined, 15, 500);
         return this.streams.main.instance;
       } catch {
@@ -88,18 +90,23 @@ userStreams = {
     this.streams.main.loading = true;
     let stream;
     try {
-      if (debug) log('requestUserMedia: stream is loading');
+      debug('requestUserMedia: stream is loading');
       stream = await navigator.mediaDevices.getUserMedia(constraints);
     } catch (err) {
       error('requestUserMedia failed', err);
       Meteor.users.update(Meteor.userId(), { $set: { 'profile.userMediaError': err.message } });
-      if (err.message === 'Permission denied') lp.notif.warning('Camera and microphone are required 😢');
-      else if (err.message === 'Permission denied by system') lp.notif.warning('Unable to access the camera and microphone');
+      if (err.name === 'NotAllowedError') {
+        if (err.message === 'Permission denied by system') lp.notif.warning('Unable to access the camera and microphone');
+        else lp.notif.warning(`You have not authorized your browser to use your camera and microphone 😢`);
+      } else if (err.name === 'OverconstrainedError') {
+        lp.notif.warning('Cameras constraints not supported');
+        debug('requestUserMedia: invalid constraints', constraints);
+      }
 
       throw err;
     } finally { this.streams.main.loading = false; }
 
-    if (debug) log('requestUserMedia: stream created', { streamId: stream.id, constraints });
+    debug('requestUserMedia: stream created', { streamId: stream.id, constraints });
     this.streams.main.instance = stream;
     window.dispatchEvent(new CustomEvent(eventTypes.onMediaStreamStateChanged, { detail: { type: streamTypes.main, state: 'ready', stream } }));
     Meteor.users.update(Meteor.userId(), { $unset: { 'profile.userMediaError': 1 } });
@@ -108,14 +115,13 @@ userStreams = {
   },
 
   async requestDisplayMedia() {
-    const debug = Meteor.user().options?.debug;
-    if (debug) log('requestDisplayMedia: start');
+    debug('requestDisplayMedia: start');
 
     const { instance: currentStream, loading } = this.streams.screen;
     if (currentStream) return currentStream;
     if (!currentStream && loading) {
       try {
-        if (debug) log('requestDisplayMedia: waiting existing stream to load…');
+        debug('requestDisplayMedia: waiting existing stream to load…');
         await waitFor(() => this.streams.screen.instance !== undefined, 20, 1000);
         return this.streams.screen.instance;
       } catch {
@@ -130,10 +136,16 @@ userStreams = {
     } catch (err) {
       error('requestDisplayMedia failed', err);
       Meteor.users.update(Meteor.userId(), { $set: { 'profile.shareScreen': false } });
+
+      if (err.name === 'NotAllowedError') {
+        if (err.message === 'Permission denied by system') lp.notif.warning('Permission denied by system');
+        else lp.notif.warning(`You have not authorized your browser to share your screen`);
+      }
+
       throw err;
     } finally { this.streams.screen.loading = false; }
 
-    if (debug) log('requestDisplayMedia: stream created', { streamId: stream.id });
+    debug('requestDisplayMedia: stream created', { streamId: stream.id });
     this.streams.screen.instance = stream;
     window.dispatchEvent(new CustomEvent(eventTypes.onMediaStreamStateChanged, { detail: { type: streamTypes.screen, state: 'ready', stream } }));
 
@@ -157,7 +169,7 @@ userStreams = {
     if (!stream) throw new Error(`unable to get a valid stream`);
 
     // ensures tracks are up-to-date
-    const { shareVideo, shareAudio } = Meteor.user().profile;
+    const { shareVideo, shareAudio } = Meteor.user({ 'profile.shareVideo': 1, 'profile.shareAudio': 1 }).profile;
     this.audio(shareAudio);
     this.video(shareVideo);
 

--- a/core/client/user-streams.js
+++ b/core/client/user-streams.js
@@ -41,16 +41,16 @@ userStreams = {
 
   screen(enabled) {
     const { instance: screenStream } = this.streams.screen;
-    if (screenStream && !enabled) {
-      this.stopTracks(screenStream);
-      this.streams.screen.instance = undefined;
-      Object.entries(peer.calls).forEach(([key, call]) => {
-        if (key.indexOf('-screen') === -1) return;
-        debug('me -> you screen ****** I stop sharing screen, call closing', key);
-        call.close();
-        delete peer.calls[key];
-      });
-    }
+    if (!screenStream || enabled) return;
+
+    this.stopTracks(screenStream);
+    this.streams.screen.instance = undefined;
+    Object.entries(peer.calls).forEach(([key, call]) => {
+      if (key.indexOf('-screen') === -1) return;
+      debug('me -> you screen ****** I stop sharing screen, call closing', key);
+      call.close();
+      delete peer.calls[key];
+    });
   },
 
   destroyStream(type) {


### PR DESCRIPTION
- Add a fallback when the unsplash API is down or the remote image is not found
- Stop updating many things on user update
- Remote user's avatar is now updated when the user is updating his avatar