### PR TITLE
Limit on-boarding image size

### DIFF
--- a/core/client/ui/user-onboarding.scss
+++ b/core/client/ui/user-onboarding.scss
@@ -55,6 +55,10 @@
     border-radius: 16px;
     padding: 40px 20px;
     position: relative;
+
+    img {
+      max-height: 40vh;
+    }
   }
 
   .direction-content {


### PR DESCRIPTION
Limit on-boarding image size to avoid scroll bar and continue button pushed out of the screen for small screen resolution.

Before:
<img width="1431" alt="Screenshot 2023-03-02 at 17 59 48" src="https://user-images.githubusercontent.com/1092138/222499796-8bb156ea-c2ce-4944-a7d1-1a09f1b6da8a.png">

After:
<img width="1436" alt="Screenshot 2023-03-02 at 17 59 28" src="https://user-images.githubusercontent.com/1092138/222499812-36a24881-5349-4952-abf6-1195219212f9.png">
